### PR TITLE
CB-13471: File Provider fix belongs in cordova-common

### DIFF
--- a/src/ConfigChanges/ConfigFile.js
+++ b/src/ConfigChanges/ConfigFile.js
@@ -193,7 +193,13 @@ function resolveConfigFilePath (project_dir, platform, file) {
         } else if (file.endsWith('config.xml')) {
             filepath = path.join(project_dir, 'app', 'src', 'main', 'res', 'xml', 'config.xml');
         } else if (file.endsWith('strings.xml')) {
+            // Plugins really shouldn't mess with strings.xml, since it's able to be localized
             filepath = path.join(project_dir, 'app', 'src', 'main', 'res', 'values', 'strings.xml');
+        }
+        else if (file.match(/res\/xml/)) {
+            // Catch-all for all other stored XML configuration in legacy plugins
+            var config_file = path.basename(file);
+            filepath = path.join(project_dir, 'app', 'src', 'main', 'res', 'xml', config_file);
         }
         return filepath;
     }

--- a/src/ConfigChanges/ConfigFile.js
+++ b/src/ConfigChanges/ConfigFile.js
@@ -195,8 +195,7 @@ function resolveConfigFilePath (project_dir, platform, file) {
         } else if (file.endsWith('strings.xml')) {
             // Plugins really shouldn't mess with strings.xml, since it's able to be localized
             filepath = path.join(project_dir, 'app', 'src', 'main', 'res', 'values', 'strings.xml');
-        }
-        else if (file.match(/res\/xml/)) {
+        } else if (file.match(/res\/xml/)) {
             // Catch-all for all other stored XML configuration in legacy plugins
             var config_file = path.basename(file);
             filepath = path.join(project_dir, 'app', 'src', 'main', 'res', 'xml', config_file);


### PR DESCRIPTION
Found that we weren't handling XML properly.  There are other paths that won't work, but I really don't want to end up doing mapping for everything, just for our core plugins. This was required to get Camera to work.