### PR TITLE
CB-13744: Recognize storyboards as XML files

### DIFF
--- a/src/ConfigChanges/ConfigChanges.js
+++ b/src/ConfigChanges/ConfigChanges.js
@@ -80,9 +80,6 @@ function PlatformMunger_apply_file_munge (file, munge, remove) {
                 if (remove) config_file.prune_child(selector, munge.parents[selector][xml_child]);
                 else config_file.graft_child(selector, munge.parents[selector][xml_child]);
             }
-	    else {
-		events.emit('warn', 'config file ' + file + ' requested for changes not found at ' + config_file.filepath + ', ignoring');
-	    }
         }
     }
 }

--- a/src/ConfigChanges/ConfigChanges.js
+++ b/src/ConfigChanges/ConfigChanges.js
@@ -79,10 +79,9 @@ function PlatformMunger_apply_file_munge (file, munge, remove) {
             if (config_file.exists) {
                 if (remove) config_file.prune_child(selector, munge.parents[selector][xml_child]);
                 else config_file.graft_child(selector, munge.parents[selector][xml_child]);
+            } else {
+                events.emit('warn', 'config file ' + file + ' requested for changes not found at ' + config_file.filepath + ', ignoring');
             }
-	    else {
-		events.emit('warn', 'config file ' + file + ' requested for changes not found at ' + config_file.filepath + ', ignoring');
-	    }
         }
     }
 }

--- a/src/ConfigChanges/ConfigChanges.js
+++ b/src/ConfigChanges/ConfigChanges.js
@@ -80,6 +80,9 @@ function PlatformMunger_apply_file_munge (file, munge, remove) {
                 if (remove) config_file.prune_child(selector, munge.parents[selector][xml_child]);
                 else config_file.graft_child(selector, munge.parents[selector][xml_child]);
             }
+	    else {
+		events.emit('warn', 'config file ' + file + ' requested for changes not found at ' + config_file.filepath + ', ignoring');
+	    }
         }
     }
 }

--- a/src/ConfigChanges/ConfigChanges.js
+++ b/src/ConfigChanges/ConfigChanges.js
@@ -79,9 +79,10 @@ function PlatformMunger_apply_file_munge (file, munge, remove) {
             if (config_file.exists) {
                 if (remove) config_file.prune_child(selector, munge.parents[selector][xml_child]);
                 else config_file.graft_child(selector, munge.parents[selector][xml_child]);
-            } else {
-                events.emit('warn', 'config file ' + file + ' requested for changes not found at ' + config_file.filepath + ', ignoring');
             }
+	    else {
+		events.emit('warn', 'config file ' + file + ' requested for changes not found at ' + config_file.filepath + ', ignoring');
+	    }
         }
     }
 }

--- a/src/ConfigChanges/ConfigFile.js
+++ b/src/ConfigChanges/ConfigFile.js
@@ -71,7 +71,7 @@ function ConfigFile_load () {
     var ext = path.extname(filepath);
     // Windows8 uses an appxmanifest, and wp8 will likely use
     // the same in a future release
-    if (ext === '.xml' || ext === '.appxmanifest') {
+    if (ext === '.xml' || ext === '.appxmanifest' || ext === '.storyboard') {
         self.type = 'xml';
         self.data = modules.xml_helpers.parseElementtreeSync(filepath);
     } else {


### PR DESCRIPTION
This is to allow customization of the CDVLaunchScreen.storyboard to
adjust contentmode and background color in config.xml.

Further:

I'm not quite sure why the logic is that only some extensions are
recognized as XML and all others as plists. Maybe the opposite would be
better?

Alternatively, an additional parameter to `<config-file>` and
`<edit-config>` to specifiy the file format could be useful.