### PR TITLE
New method ConfigParser.getByName to find a resource containig a stri…

### DIFF
--- a/src/ConfigParser/ConfigParser.js
+++ b/src/ConfigParser/ConfigParser.js
@@ -225,6 +225,17 @@ ConfigParser.prototype = {
                     (!res.height || (height === res.height)));
             })[0] || null;
         };
+        
+        /**
+         * Returns resource with specified text in its source.
+         * @param  {string} source name to search.
+         * @return {Resource}       Resource object or null if not found.
+         */
+        ret.getByName = function (name) {
+            return ret.filter(function (res) {
+                return res.src.indexOf(name) > -1;
+            })[0] || null;
+        };
 
         /**
          * Returns resource with specified density.


### PR DESCRIPTION
…ng in its src.

Needed to fix cordova-ios, which is erroneously using getBySize when more than one resource have the same dimensions.