### PR TITLE
CB-13770: Warn when <edit-config> or <config-file> not found

### DIFF
--- a/src/ConfigChanges/ConfigChanges.js
+++ b/src/ConfigChanges/ConfigChanges.js
@@ -79,6 +79,8 @@ function PlatformMunger_apply_file_munge (file, munge, remove) {
             if (config_file.exists) {
                 if (remove) config_file.prune_child(selector, munge.parents[selector][xml_child]);
                 else config_file.graft_child(selector, munge.parents[selector][xml_child]);
+            } else {
+                events.emit('warn', 'config file ' + file + ' requested for changes not found at ' + config_file.filepath + ', ignoring');
             }
         }
     }


### PR DESCRIPTION
When a file is referenced in `<edit-config>` or `<config-file>` is not found, no warning or error is generated.

This change logs a warning, and includes where the file is actually expected to be based on the filename provided.

@jcaron23 This was your second commit on a previous PR that was asked to be split. The change looks good to me, so I'm opening this so we can get it merged in.