### PR TITLE
Replace indexOf where better alternatives are available

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "plist": "^3.0.1",
     "q": "^1.4.1",
     "shelljs": "^0.8.1",
+    "strip-bom": "^3.0.0",
     "underscore": "^1.8.3"
   },
   "devDependencies": {

--- a/spec/fixtures/projects/windows/www/cordova-2.6.0.js
+++ b/spec/fixtures/projects/windows/www/cordova-2.6.0.js
@@ -2611,7 +2611,7 @@ function getBasicAuthHeader(urlString) {
         var origin = protocol + url.host;
 
         // check whether there are the username:password credentials in the url
-        if (url.href.indexOf(origin) != 0) { // credentials found
+        if (!url.href.startsWith(origin)) { // credentials found
             var atIndex = url.href.indexOf("@");
             credentials = url.href.substring(protocol.length, atIndex);
         }
@@ -6266,7 +6266,7 @@ module.exports = {
 
         var name = "unknown";
         hostNames.some(function (nm) {
-            if (nm.displayName.indexOf(".local") > -1) {
+            if (nm.displayName.includes(".local")) {
                 name = nm.displayName.split(".local")[0];
                 return true;
             }

--- a/src/ConfigChanges/ConfigFile.js
+++ b/src/ConfigChanges/ConfigFile.js
@@ -168,16 +168,16 @@ function resolveConfigFilePath (project_dir, platform, file) {
 
     file = path.normalize(file);
 
-    if (file.indexOf('*') > -1) {
+    if (file.includes('*')) {
         // handle wildcards in targets using glob.
         matches = modules.glob.sync(path.join(project_dir, '**', file));
         if (matches.length) filepath = matches[0];
 
         // [CB-5989] multiple Info.plist files may exist. default to $PROJECT_NAME-Info.plist
-        if (matches.length > 1 && file.indexOf('-Info.plist') > -1) {
+        if (matches.length > 1 && file.includes('-Info.plist')) {
             var plistName = getIOSProjectname(project_dir) + '-Info.plist';
             for (var i = 0; i < matches.length; i++) {
-                if (matches[i].indexOf(plistName) > -1) {
+                if (matches[i].includes(plistName)) {
                     filepath = matches[i];
                     break;
                 }

--- a/src/ConfigParser/ConfigParser.js
+++ b/src/ConfigParser/ConfigParser.js
@@ -57,7 +57,7 @@ function getCordovaNamespacePrefix (doc) {
     var rootAtribs = Object.getOwnPropertyNames(doc.getroot().attrib);
     var prefix = 'cdv';
     for (var j = 0; j < rootAtribs.length; j++) {
-        if (rootAtribs[j].indexOf('xmlns:') === 0 &&
+        if (rootAtribs[j].startsWith('xmlns:') &&
             doc.getroot().attrib[rootAtribs[j]] === 'http://cordova.apache.org/ns/1.0') {
             var strings = rootAtribs[j].split(':');
             prefix = strings[1];

--- a/src/ConfigParser/ConfigParser.js
+++ b/src/ConfigParser/ConfigParser.js
@@ -86,6 +86,11 @@ function findElementAttributeValue (attributeName, elems) {
     return value || '';
 }
 
+function removeChildren (el, selector) {
+    const matches = el.findall(selector);
+    matches.forEach(child => el.remove(child));
+}
+
 ConfigParser.prototype = {
     getAttribute: function (attr) {
         return this.doc.getroot().attrib[attr];
@@ -428,17 +433,10 @@ ConfigParser.prototype = {
      * @param id name of the plugin
      */
     removePlugin: function (id) {
-        if (id) {
-            var plugins = this.doc.findall('./plugin/[@name="' + id + '"]')
-                .concat(this.doc.findall('./feature/param[@name="id"][@value="' + id + '"]/..'));
-            var children = this.doc.getroot().getchildren();
-            plugins.forEach(function (plugin) {
-                var idx = children.indexOf(plugin);
-                if (idx > -1) {
-                    children.splice(idx, 1);
-                }
-            });
-        }
+        if (!id) return;
+        const root = this.doc.getroot();
+        removeChildren(root, `./plugin/[@name="${id}"]`);
+        removeChildren(root, `./feature/param[@name="id"][@value="${id}"]/..`);
     },
 
     // Add any element to the root
@@ -469,14 +467,7 @@ ConfigParser.prototype = {
      * @param  {String} name the engine name.
      */
     removeEngine: function (name) {
-        var engines = this.doc.findall('./engine/[@name="' + name + '"]');
-        for (var i = 0; i < engines.length; i++) {
-            var children = this.doc.getroot().getchildren();
-            var idx = children.indexOf(engines[i]);
-            if (idx > -1) {
-                children.splice(idx, 1);
-            }
-        }
+        removeChildren(this.doc.getroot(), `./engine/[@name="${name}"]`);
     },
     getEngines: function () {
         var engines = this.doc.findall('./engine');

--- a/src/CordovaLogger.js
+++ b/src/CordovaLogger.js
@@ -161,9 +161,9 @@ CordovaLogger.prototype.setLevel = function (logLevel) {
  * @return  {CordovaLogger}     Current instance, to allow calls chaining.
  */
 CordovaLogger.prototype.adjustLevel = function (opts) {
-    if (opts.verbose || (Array.isArray(opts) && opts.indexOf('--verbose') !== -1)) {
+    if (opts.verbose || (Array.isArray(opts) && opts.includes('--verbose'))) {
         this.setLevel('verbose');
-    } else if (opts.silent || (Array.isArray(opts) && opts.indexOf('--silent') !== -1)) {
+    } else if (opts.silent || (Array.isArray(opts) && opts.includes('--silent'))) {
         this.setLevel('error');
     }
 
@@ -209,7 +209,7 @@ function formatError (error, isVerbose) {
         message = error;
     }
 
-    if (typeof message === 'string' && message.toUpperCase().indexOf('ERROR:') !== 0) {
+    if (typeof message === 'string' && !message.toUpperCase().startsWith('ERROR:')) {
         // Needed for backward compatibility with external tools
         message = 'Error: ' + message;
     }

--- a/src/PlatformJson.js
+++ b/src/PlatformJson.js
@@ -111,7 +111,7 @@ PlatformJson.prototype.addPluginMetadata = function (pluginInfo) {
         })
         .filter(function (metadata) {
             // Filter out modules which are already added to metadata
-            return installedPaths.indexOf(metadata.file) === -1;
+            return !installedPaths.includes(metadata.file);
         });
 
     this.root.modules = installedModules.concat(modulesToInstall);
@@ -151,7 +151,7 @@ PlatformJson.prototype.removePluginMetadata = function (pluginInfo) {
     this.root.modules = installedModules
         .filter(function (installedModule) {
             // Leave only those metadatas which 'file' is not in removed modules
-            return (modulesToRemove.indexOf(installedModule.file) === -1);
+            return !modulesToRemove.includes(installedModule.file);
         });
 
     if (this.root.plugin_metadata) {

--- a/src/superspawn.js
+++ b/src/superspawn.js
@@ -30,7 +30,7 @@ var iswin32 = process.platform === 'win32';
 function resolveWindowsExe (cmd) {
     var winExtensions = ['.exe', '.bat', '.cmd', '.js', '.vbs'];
     function isValidExe (c) {
-        return winExtensions.indexOf(path.extname(c)) !== -1 && fs.existsSync(c);
+        return winExtensions.includes(path.extname(c)) && fs.existsSync(c);
     }
     if (isValidExe(cmd)) {
         return cmd;

--- a/src/util/xml-helpers.js
+++ b/src/util/xml-helpers.js
@@ -25,6 +25,7 @@ var fs = require('fs');
 var path = require('path');
 var _ = require('underscore');
 var et = require('elementtree');
+var stripBom = require('strip-bom');
 
 /* eslint-disable no-useless-escape */
 var ROOT = /^\/([^\/]*)/;
@@ -177,11 +178,7 @@ module.exports = {
     },
 
     parseElementtreeSync: function (filename) {
-        var contents = fs.readFileSync(filename, 'utf-8');
-        if (contents) {
-            // Windows is the BOM. Skip the Byte Order Mark.
-            contents = contents.substring(contents.indexOf('<'));
-        }
+        var contents = stripBom(fs.readFileSync(filename, 'utf-8'));
         return new et.ElementTree(et.XML(contents));
     },
 

--- a/src/util/xml-helpers.js
+++ b/src/util/xml-helpers.js
@@ -257,7 +257,7 @@ var BLACKLIST = ['platform', 'feature', 'plugin', 'engine'];
 var SINGLETONS = ['content', 'author', 'name'];
 function mergeXml (src, dest, platform, clobber) {
     // Do nothing for blacklisted tags.
-    if (BLACKLIST.indexOf(src.tag) !== -1) return;
+    if (BLACKLIST.includes(src.tag)) return;
 
     // Handle attributes
     Object.getOwnPropertyNames(src.attrib).forEach(function (attribute) {
@@ -289,9 +289,9 @@ function mergeXml (src, dest, platform, clobber) {
         var query = srcTag + '';
         var shouldMerge = true;
 
-        if (BLACKLIST.indexOf(srcTag) !== -1) return;
+        if (BLACKLIST.includes(srcTag)) return;
 
-        if (SINGLETONS.indexOf(srcTag) !== -1) {
+        if (SINGLETONS.includes(srcTag)) {
             foundChild = dest.find(query);
             if (foundChild) {
                 destChild = foundChild;


### PR DESCRIPTION
This replaces most instances of `indexOf` usage with more obvious code; mostly `includes` and `startsWith`. The remaining instances are either in fixtures or really justified.