### PR TITLE
[WIP] package.json use plist@2 to resolve engine warning on node 4 in 2.2.x patch release

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "elementtree": "0.1.6",
     "glob": "^5.0.13",
     "minimatch": "^3.0.0",
-    "plist": "^3.0.1",
+    "plist": "^2.1.0",
     "q": "^1.4.1",
     "shelljs": "^0.5.3",
     "underscore": "^1.8.3",


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

All

### What does this PR do?

I just discovered that using plist@3 triggers an unwanted engine warning on Node 4 like this:

```sh
npm WARN engine plist@3.0.1: wanted: {"node":">=6"} (current: {"node":"4.9.1","npm":"2.15.11"})
```

Using plist@2 (plist@^2.1.0) resolves this warning on Node 4 without triggering any `npm audit` warnings at this time.

### What testing has been done on this change?

- `npm test` passes with this change on both Windows and mac development systems
- TODO: test with cordova-android and/or cordova-ios platform in a real Cordova app

### Checklist

- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database - TBD
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected. - TBD
- ~~Added automated test coverage as appropriate for this change.~~