### PR TITLE
CB-14099 osx: Fixed Resolve Config Path for OSX

### DIFF
--- a/spec/ConfigChanges/ConfigFile.spec.js
+++ b/spec/ConfigChanges/ConfigFile.spec.js
@@ -73,6 +73,12 @@ describe('ConfigFile tests', function () {
     });
 
     it('resolveConfigFilePath should return file path', function () {
+        spyOn(configFile, 'getIOSProjectname').and.returnValue('osxpath');
+        var configPath = path.join('project_dir', 'osxpath', 'config.xml');
+        expect(configFile.resolveConfigFilePath('project_dir', 'osx', 'config.xml')).toBe(configPath);
+    });
+
+    it('resolveConfigFilePath should return file path', function () {
         var configPath = path.join('project_dir', 'config.xml');
         expect(configFile.resolveConfigFilePath('project_dir', 'ubuntu', 'config.xml')).toBe(configPath);
     });

--- a/src/ConfigChanges/ConfigFile.js
+++ b/src/ConfigChanges/ConfigFile.js
@@ -211,9 +211,12 @@ function resolveConfigFilePath (project_dir, platform, file) {
     if (file === 'config.xml') {
         if (platform === 'ubuntu') {
             filepath = path.join(project_dir, 'config.xml');
-        } else if (platform === 'ios') {
-            var iospath = module.exports.getIOSProjectname(project_dir);
-            filepath = path.join(project_dir, iospath, 'config.xml');
+        } else if (platform === 'ios' || platform === 'osx') {
+            filepath = path.join(
+                project_dir,
+                module.exports.getIOSProjectname(project_dir),
+                'config.xml'
+            );
         } else {
             matches = modules.glob.sync(path.join(project_dir, '**', 'config.xml'));
             if (matches.length) filepath = matches[0];
@@ -225,7 +228,7 @@ function resolveConfigFilePath (project_dir, platform, file) {
     return filepath;
 }
 
-// Find out the real name of an iOS project
+// Find out the real name of an iOS or OSX project
 // TODO: glob is slow, need a better way or caching, or avoid using more than once.
 function getIOSProjectname (project_dir) {
     var matches = modules.glob.sync(path.join(project_dir, '*.xcodeproj'));


### PR DESCRIPTION
### Platforms affected
OSX

### What does this PR do?
Updates the Resolve Config Path for OSX.

I have identified that the initial build was successful but the consecutive builds fail because it updated the incorrect `config.xml` file.

I was able to narrow down this issue coming from the `resolveConfigFilePath` method. This method currently handles special cases for Android, Ubuntu, and iOS. For all other platforms, it would fall back to glob for the config.xml. This is what was happens for OSX.

When building for the first time, you have installed a fresh copy of the OSX platform. 
At this time, when globbing, it will find the correct config.xml file located in `/.tests/<APP_NAME>/platforms/osx/<APP_NAME>/config.xml`.

In the consecutive build, when globbing, it finds and updates the incorrect config.xml file. The file it finds is: `/.tests/osx/<APP_NAME>/platforms/osx/build/<APP_NAME>.app/Contents/Resources/config.xml`
This is because of the folder/file order structure and globbing nature. Since this file was created after the first build (build history), it happens to find this file first.

### What testing has been done on this change?
- https://travis-ci.org/erisu/cordova-common/builds/396805720

I also followed the reported issue steps:
- $ cordova create myapp org.apache.myapp myapp
- $ cordova platform add osx
  - I used a cloned version of `cordova-osx@master` with modified `package.json` to use `cordova-common#CB-14099` with my fix.
- $ cordova plugin add cordova-plugin-file
- $ cordova run osx
  - I ran this step 3x times.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
