### PR TITLE
CB-12016: (all) Removed cordova-registry-mapper dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "dependencies": {
     "ansi": "^0.3.1",
     "bplist-parser": "^0.1.0",
-    "cordova-registry-mapper": "^1.1.8",
     "elementtree": "0.1.7",
     "fs-extra": "^6.0.1",
     "glob": "^7.1.2",

--- a/src/PlatformJson.js
+++ b/src/PlatformJson.js
@@ -17,8 +17,6 @@
 var fs = require('fs-extra');
 var path = require('path');
 var mungeutil = require('./ConfigChanges/munge-util');
-var pluginMappernto = require('cordova-registry-mapper').newToOld;
-var pluginMapperotn = require('cordova-registry-mapper').oldToNew;
 
 function PlatformJson (filePath, platform, root) {
     this.filePath = filePath;
@@ -47,10 +45,7 @@ PlatformJson.prototype.save = function () {
  * @return {Boolean} true if plugin installed as top-level, otherwise false.
  */
 PlatformJson.prototype.isPluginTopLevel = function (pluginId) {
-    var installedPlugins = this.root.installed_plugins;
-    return installedPlugins[pluginId] ||
-        installedPlugins[pluginMappernto[pluginId]] ||
-        installedPlugins[pluginMapperotn[pluginId]];
+    return this.root.installed_plugins[pluginId];
 };
 
 /**
@@ -61,10 +56,7 @@ PlatformJson.prototype.isPluginTopLevel = function (pluginId) {
  * @return {Boolean} true if plugin installed as a dependency, otherwise false.
  */
 PlatformJson.prototype.isPluginDependent = function (pluginId) {
-    var dependentPlugins = this.root.dependent_plugins;
-    return dependentPlugins[pluginId] ||
-        dependentPlugins[pluginMappernto[pluginId]] ||
-        dependentPlugins[pluginMapperotn[pluginId]];
+    return this.root.dependent_plugins[pluginId];
 };
 
 /**


### PR DESCRIPTION
### Platforms affected
all

### What does this PR do?
Remove a forgotten dead dependency.

Ticket [CB-12016](https://issues.apache.org/jira/browse/CB-12016) was to remove this dependency and had been resolved but appears `cordova-common` was forgotten.

### What testing has been done on this change?
Tested adding plugins with old and new package name.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
