### PR TITLE
 CB-14263: (android) make cordova plugin compatible with cordova-android 7

### DIFF
--- a/src/PluginInfo/PluginInfo.js
+++ b/src/PluginInfo/PluginInfo.js
@@ -130,7 +130,7 @@ function PluginInfo (dirname) {
 
     function _parseConfigFile (platform, tag) {
         var target = tag.attrib['target'];
-        if (platform == 'android') {
+        if (platform === 'android') {
             if (target === 'AndroidManifest.xml') {
                 target = path.join('app', 'src', 'main', 'AndroidManifest.xml');
             } else if (target.endsWith('config.xml')) {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
cordova-android

### What does this PR do?
My PR supports alias path in cordova-plugin config-file tag. 
It will makes older cordova plugins's android config-file target compatible with cordova-android 7.

There is lots of problem with cordova-android 7 & cordova plugins. Many of cordova plugins still not upgraded to cordova-android 7 and there is limitation to wait for them to update their plugin.xml. So i think we need 

### What testing has been done on this change?
I create cordova-android 7 project with install cordova-plugin-device (only cordova-android <=6 support plugin) 
and install via `npm i -g https://github.com/leo6104/cordova-cli.git` 
and run `cordova build android` 
and check `platforms/android/app/src/main/res/xml/config.xml` to correctly inject <feature> tag

I also test this commit to my production hybrid app (30k~40k user scale DAU app - 14 cordova plugins)

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
