### PR TITLE
Make PlatformJson.generateMetadata more readable

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "ansi": "^0.3.1",
     "bplist-parser": "^0.1.0",
     "elementtree": "0.1.7",
+    "endent": "^1.1.1",
     "fs-extra": "^6.0.1",
     "glob": "^7.1.2",
     "minimatch": "^3.0.0",

--- a/src/PlatformJson.js
+++ b/src/PlatformJson.js
@@ -16,6 +16,7 @@
 
 var fs = require('fs-extra');
 var path = require('path');
+var endent = require('endent');
 var mungeutil = require('./ConfigChanges/munge-util');
 
 function PlatformJson (filePath, platform, root) {
@@ -182,15 +183,13 @@ PlatformJson.prototype.makeTopLevel = function (pluginId) {
  * @returns {String} cordova_plugins.js contents
  */
 PlatformJson.prototype.generateMetadata = function () {
-    return [
-        'cordova.define(\'cordova/plugin_list\', function(require, exports, module) {',
-        'module.exports = ' + JSON.stringify(this.root.modules, null, 2) + ';',
-        'module.exports.metadata = ',
-        '// TOP OF METADATA',
-        JSON.stringify(this.root.plugin_metadata, null, 2) + ';',
-        '// BOTTOM OF METADATA',
-        '});' // Close cordova.define.
-    ].join('\n');
+    const stringify = o => JSON.stringify(o, null, 2);
+    return endent`
+        cordova.define('cordova/plugin_list', function(require, exports, module) {
+          module.exports = ${stringify(this.root.modules)};
+          module.exports.metadata = ${stringify(this.root.plugin_metadata)};
+        });
+    `;
 };
 
 /**


### PR DESCRIPTION
Had this lying around. No functional changes besides the formatting of the generated file. Had to modify the tests because of the changed formatting, though.