### PR TITLE
Fix xml-helpers issue by adding close tag

### DIFF
--- a/spec/fixtures/test-config0.xml
+++ b/spec/fixtures/test-config0.xml
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='utf-8'?>
+<widget android-packageName="io.cordova.hellocordova.android" id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+    <name>Hello Cordova</name>
+    <description>
+        A sample Apache Cordova application that responds to the deviceready event.
+    </description>
+    <author email="dev@cordova.apache.org" href="http://cordova.io">
+        Apache Cordova Team
+    </author>
+    <content src="index.html" />
+    <access origin="*" />
+</widget>

--- a/spec/util/xml-helpers.spec.js
+++ b/spec/util/xml-helpers.spec.js
@@ -209,6 +209,12 @@ describe('xml-helpers', function () {
             xml_helpers.graftXML(config_xml, children, '/*');
             expect(config_xml.findall('access').length).toEqual(3);
         });
+        it('Test 020-1 : should create parent', function () {
+            var config_xml0 = xml_helpers.parseElementtreeSync(path.join(__dirname, '../fixtures/test-config0.xml'));
+            var children = plugin_xml.find('platform[@name="ios"]/config-file').getchildren();
+            xml_helpers.graftXML(config_xml0, children, '/widget/plugins');
+            expect(config_xml0.find('plugins').getchildren().length).toEqual(1);
+        });
     });
 
     describe('graftXMLMerge', function () {

--- a/src/util/xml-helpers.js
+++ b/src/util/xml-helpers.js
@@ -61,7 +61,7 @@ module.exports = {
         if (!parent) {
             // Try to create the parent recursively if necessary
             try {
-                var parentToCreate = et.XML('<' + path.basename(selector) + '>');
+                var parentToCreate = et.XML('<' + path.basename(selector) + '/>');
                 var parentSelector = path.dirname(selector);
 
                 this.graftXML(doc, [parentToCreate], parentSelector);


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
common

### What does this PR do?
This PR is very simple.
Fix xml-helpers graftXML function to create parent element with 'closed tag'.
(i.e.  `'<' + tag_name + '>'` is changed to `'<' + tag_name+ '/>'`)

Because the current cordova-common uses elementtree@0.1.7 which depends on sax@1.1.4,  and the sax@1.1.4 checks 'closed tag' strictly and does not accept 'unclosed tag'.
The old version of cordova-common uses elementtree@0.1.6 which depends on sax@0.3.5, and the sax@0.3.5 checks 'closed tag' loosely. 

### What testing has been done on this change?
We tests this by cordova-ios tests in which pluginHandler.spec.js Test 028 encounters this issue.
Further I added new tests TEST 20-1 in xml-helpers.spec.js in this PR. 

### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
