### PR TITLE
CB-13496: Fix greedy regex in plist-helpers

### DIFF
--- a/spec/plist-helpers.spec.js
+++ b/spec/plist-helpers.spec.js
@@ -58,3 +58,35 @@ describe('prunePLIST', function () {
         done();
     });
 });
+
+describe('plistGraft', function () {
+    let doc = {
+        'keychain-access-groups': [
+            '$(AppIdentifierPrefix)io.cordova.hellocordova',
+            '$(AppIdentifierPrefix)com.example.mylib'
+        ]
+    };
+
+    let xml = '<array>' +
+                '<string>$(AppIdentifierPrefix)io.cordova.hellocordova</string>' +
+                '<string>$(AppIdentifierPrefix)com.example.mylib</string>' +
+              '</array>';
+
+    let selector = 'keychain-access-groups';
+
+    it('Test 01: should not mangle existing plist entries', function (done) {
+        var graftStatus = plistHelpers.graftPLIST(doc, xml, selector);
+
+        expect(graftStatus).toBeTruthy();
+        expect(doc).toEqual(
+            {
+                'keychain-access-groups': [
+                    '$(AppIdentifierPrefix)io.cordova.hellocordova',
+                    '$(AppIdentifierPrefix)com.example.mylib'
+                ]
+            }
+        );
+
+        done();
+    });
+});

--- a/src/util/plist-helpers.js
+++ b/src/util/plist-helpers.js
@@ -80,7 +80,7 @@ function pruneOBJECT (doc, selector, fragment) {
 
 function nodeEqual (node1, node2) {
     if (typeof node1 !== typeof node2) { return false; } else if (typeof node1 === 'string') {
-        node2 = escapeRE(node2).replace(/\\\$\S+/gm, '(.*?)');
+        node2 = escapeRE(node2).replace(/\\\$\(\S+\)/gm, '(.*?)');
         return new RegExp('^' + node2 + '$').test(node1);
     } else {
         for (var key in node2) {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS

### What does this PR do?
Resolves an issue where a regex was overly greedy when comparing plist entries for merging and could result in collapsing several of them into a single entry.

### What testing has been done on this change?
Added a test that fails with current master and passes with this change, based on the details provided by @knight9999 in the JIRA bug. It sounds like this might be the cause of GH-44 as well (/fyi @donnie-jp).

Now, my fix assumes that we're always looking for `$(something)` and not just `$something`, which *might* not be a safe assumption. Unfortunately I'm not well-versed enough in iOS stuff to know :(


### Checklist
- [x] Reported an issue in the JIRA database
- [x] Commit message follows the format
- [x] Added automated test coverage as appropriate for this change.
