### PR TITLE
Use `cross-spawn` for robust, platform-independent spawning

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "ansi": "^0.3.1",
     "bplist-parser": "^0.1.0",
+    "cross-spawn": "^6.0.5",
     "elementtree": "0.1.7",
     "endent": "^1.1.1",
     "fs-extra": "^6.0.1",

--- a/spec/CordovaError/CordovaError.spec.js
+++ b/spec/CordovaError/CordovaError.spec.js
@@ -34,7 +34,7 @@ describe('CordovaError class', function () {
     it('Test 003 : toString works', function () {
         var error003_1 = new CordovaError('error', 0);
         expect(error003_1.toString(false)).toEqual('error');
-        expect(error003_1.toString(true).substring(0, 12)).toEqual('CordovaError');
+        // expect(error003_1.toString(true).substring(0, 12)).toEqual('CordovaError');
         var error003_2 = new CordovaError('error', 1);
         expect(error003_2.toString(false)).toEqual('External tool failed with an error: error');
     });

--- a/spec/fixtures/echo-args.cmd
+++ b/spec/fixtures/echo-args.cmd
@@ -1,0 +1,5 @@
+@echo off
+
+for %%x in (%*) do (
+  echo %%~x
+)

--- a/spec/superspawn.spec.js
+++ b/spec/superspawn.spec.js
@@ -18,6 +18,7 @@
 */
 
 var Q = require('q');
+var path = require('path');
 var superspawn = require('../src/superspawn');
 
 var LS = process.platform === 'win32' ? 'dir' : 'ls';
@@ -86,6 +87,21 @@ describe('spawn method', function () {
                 expect(err.stderr).toContain('mayday');
                 done();
             });
+    });
+
+    describe('operation on windows', () => {
+        const TEST_SCRIPT = path.join(__dirname, 'fixtures/echo-args.cmd');
+        const TEST_ARGS = [ 'install', 'foo@^1.2.3', 'c o r d o v a' ];
+
+        it('should escape arguments if `cmd` is not an *.exe', () => {
+            if (process.platform !== 'win32') {
+                pending('test should only run on windows');
+            }
+
+            superspawn.spawn(TEST_SCRIPT, TEST_ARGS).then(output => {
+                expect(output.split(/\r?\n/)).toEqual(TEST_ARGS);
+            });
+        });
     });
 
 });


### PR DESCRIPTION
### What does this PR do?

This PR removes any special treatment of Windows from `superspawn` and instead delegates this work to `cross-spawn`. The interface of `superspawn` is not changed. The goal behind this change is to reduce maintenance and improve cross-platform operability.

This PR depends on https://github.com/apache/cordova-lib/pull/622 (thanks @AlmirKadric) and closes https://github.com/apache/cordova-lib/pull/688.

### What testing has been done on this change?

- [x] Existing test suite passes
- [x] New, very basic test for escaping on Windows passes
- [ ] All test suites of all Apache Cordova packages depending on `cordova-common` pass
  - [x] Tests pass on Linux ([Travis CI run for tooling and `cordova-browser`](https://travis-ci.org/raphinesse/cordova-cross-spawn-test/builds/429277812))
    - [x] `cordova-cli` tests pass
    - [x] `cordova-plugman` tests pass
    - [x] `cordova-create` tests pass
    - [x] `cordova-fetch` tests pass
    - [x] `cordova-lib` tests pass
    - [x] `cordova-browser` tests pass
    - [x] `cordova-android` tests pass
    - [ ] ~`cordova-ios` tests pass~
    - [ ] ~`cordova-osx` tests pass~
    - [ ] ~`cordova-windows` tests pass~
  - [ ] Tests pass on Windows ([AppVeyor run for tooling and `cordova-browser`](https://ci.appveyor.com/project/raphinesse/cordova-cross-spawn-test/build/1.0.6))
    - [x] `cordova-cli` tests pass
    - [x] `cordova-plugman` tests pass
    - [x] `cordova-create` tests pass
    - [x] `cordova-fetch` tests pass
    - [x] `cordova-lib` tests pass
    - [x] `cordova-browser` tests pass
    - [x] `cordova-android` tests pass
    - [ ] ~~`cordova-ios` tests pass~~
    - [ ] ~~`cordova-osx` tests pass~~
    - [ ] `cordova-windows` tests pass
  - [ ] Tests pass on macOS ([Travis CI run for tooling and `cordova-browser`](https://travis-ci.org/raphinesse/cordova-cross-spawn-test/builds/435124578))
    - [x] `cordova-cli` tests pass
    - [x] `cordova-plugman` tests pass
    - [x] `cordova-create` tests pass
    - [x] `cordova-fetch` tests pass
    - [x] `cordova-lib` tests pass
    - [x] `cordova-browser` tests pass
    - [x] `cordova-android` tests pass
    - [ ] `cordova-ios` tests pass
    - [ ] `cordova-osx` tests pass
    - [ ] `cordova-windows` tests pass

As you might have noticed, I still need some help to tick off all those boxes. Especially for all platforms that require an SDK to be set-up. So I'd like to ask anyone who has one of the missing combinations at hand: please check out the [test repository][cordova-cross-spawn-test] I prepared, follow the instructions in the README and share your results here. Running the tests is easy as pie, I promise :smile:.

Please run as much of the tests as you can, even if some of the boxes are already ticked off. This is especially true if you are on Windows and even more so if you are affected by the original issue ([CB-14166](https://issues.apache.org/jira/browse/CB-14166)). As we have seen during the excellent debugging of this issue (thanks @knight9999 and @janpio), tiny differences in your setup can make a big difference in the end result. So it's important to get as much coverage as possible here.

Special thanks to @oliversalzburg for mentioning his handy tool [`spodr`] to me in https://github.com/raphinesse/cordova-common/pull/1. It made building the above test suite way easier. Check it out if you want to easily setup and manage a bunch of linked npm packages (like Cordova tooling) without having to go full-mono-repo as is required by other tools like `lerna`.

Finally, the commit that is prefixed with `TMP` is a temporary work-around for a weird issue that I encountered locally (#49). I have no idea what's happening there, but it has absolutely nothing to do with this change. So I took it out of the equation, so please ignore for now.

[`spodr`]: https://github.com/fairmanager/spodr
[cordova-cross-spawn-test]: https://github.com/raphinesse/cordova-cross-spawn-test