### PR TITLE
Cordova events test updates in spec

### DIFF
--- a/spec/events.spec.js
+++ b/spec/events.spec.js
@@ -17,31 +17,67 @@
     under the License.
 */
 
-var events = require('../src/events');
+const events = require('../src/events');
 
 describe('Cordova events', function () {
+    describe('emit method', function () {
+        it('Test 001 : should emit events to a listener', function () {
+            const logSpy = jasmine.createSpy('logSpy');
+            events.on('log', logSpy);
+
+            events.emit('log', 'a test message');
+            expect(logSpy).toHaveBeenCalledWith('a test message');
+        });
+
+        it('Test 002 : should report if there were any listeners or not', function () {
+            const r1 = events.emit('myname', 'first');
+            expect(r1).toBe(false);
+
+            const listenerSpy = jasmine.createSpy('listenerSpy');
+            events.on('myname', listenerSpy);
+            const r2 = events.emit('myname', 'second');
+            expect(r2).toBe(true);
+            expect(listenerSpy).toHaveBeenCalled();
+        });
+    });
+
     describe('forwardEventsTo method', function () {
         afterEach(function () {
             events.forwardEventsTo(null);
         });
-        it('Test 001 : should not go to infinite loop when trying to forward to self', function () {
+
+        it('Test 003 : should forward events to another event emitter', function () {
+            const EventEmitter = require('events').EventEmitter;
+            const anotherEventEmitter = new EventEmitter();
+            const logSpy = jasmine.createSpy('logSpy');
+            anotherEventEmitter.on('log', logSpy);
+
+            events.forwardEventsTo(anotherEventEmitter);
+            events.emit('log', 'forwarding test message');
+            expect(logSpy).toHaveBeenCalledWith('forwarding test message');
+        });
+
+        it('Test 004 : should not go to infinite loop when trying to forward to self', function () {
             expect(function () {
                 events.forwardEventsTo(events);
                 events.emit('log', 'test message');
             }).not.toThrow();
         });
-        it('Test 002 : should reset forwarding after trying to forward to self', function () {
-            var EventEmitter = require('events').EventEmitter;
-            var anotherEventEmitter = new EventEmitter();
-            var logSpy = jasmine.createSpy('logSpy');
+
+        it('Test 005 : should reset forwarding after trying to forward to self', function () {
+            const EventEmitter = require('events').EventEmitter;
+            const anotherEventEmitter = new EventEmitter();
+            const logSpy = jasmine.createSpy('logSpy');
             anotherEventEmitter.on('log', logSpy);
 
+            // should forward events to another event emitter at this point
             events.forwardEventsTo(anotherEventEmitter);
             events.emit('log', 'test message #1');
-            expect(logSpy).toHaveBeenCalled();
+            expect(logSpy).toHaveBeenCalledWith('test message #1');
 
             logSpy.calls.reset();
 
+            // should *not* forward events to another event emitter at this point
             events.forwardEventsTo(events);
             events.emit('log', 'test message #2');
             expect(logSpy).not.toHaveBeenCalled();

--- a/spec/events.spec.js
+++ b/spec/events.spec.js
@@ -19,30 +19,32 @@
 
 var events = require('../src/events');
 
-describe('forwardEventsTo method', function () {
-    afterEach(function () {
-        events.forwardEventsTo(null);
-    });
-    it('Test 001 : should not go to infinite loop when trying to forward to self', function () {
-        expect(function () {
+describe('Cordova events', function () {
+    describe('forwardEventsTo method', function () {
+        afterEach(function () {
+            events.forwardEventsTo(null);
+        });
+        it('Test 001 : should not go to infinite loop when trying to forward to self', function () {
+            expect(function () {
+                events.forwardEventsTo(events);
+                events.emit('log', 'test message');
+            }).not.toThrow();
+        });
+        it('Test 002 : should reset forwarding after trying to forward to self', function () {
+            var EventEmitter = require('events').EventEmitter;
+            var anotherEventEmitter = new EventEmitter();
+            var logSpy = jasmine.createSpy('logSpy');
+            anotherEventEmitter.on('log', logSpy);
+
+            events.forwardEventsTo(anotherEventEmitter);
+            events.emit('log', 'test message #1');
+            expect(logSpy).toHaveBeenCalled();
+
+            logSpy.calls.reset();
+
             events.forwardEventsTo(events);
-            events.emit('log', 'test message');
-        }).not.toThrow();
-    });
-    it('Test 002 : should reset forwarding after trying to forward to self', function () {
-        var EventEmitter = require('events').EventEmitter;
-        var anotherEventEmitter = new EventEmitter();
-        var logSpy = jasmine.createSpy('logSpy');
-        anotherEventEmitter.on('log', logSpy);
-
-        events.forwardEventsTo(anotherEventEmitter);
-        events.emit('log', 'test message #1');
-        expect(logSpy).toHaveBeenCalled();
-
-        logSpy.calls.reset();
-
-        events.forwardEventsTo(events);
-        events.emit('log', 'test message #2');
-        expect(logSpy).not.toHaveBeenCalled();
+            events.emit('log', 'test message #2');
+            expect(logSpy).not.toHaveBeenCalled();
+        });
     });
 });


### PR DESCRIPTION
* Move existing `forwardEventsTo` method tests into `Cordova events` section
* Add Cordova events emit tests
* other minor Cordova events test updates

Motivation:

Without these updates it would be possible for the tests to pass with `return` removed from the following line or the following line completely removed: <https://github.com/apache/cordova-common/blob/6667cfcf1a131b80e09e1410e5166e5f0a420f59/src/events.js#L71>

I think these tests are needed to ensure nothing goes wrong when refactoring events.js into a singleton class as discussed in <https://github.com/apache/cordova-common/pull/53#issuecomment-443561178>.