### PR TITLE
Cordova events singleton object

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -17,56 +17,56 @@
     under the License.
 */
 
-var EventEmitter = require('events').EventEmitter;
+const EventEmitter = require('events').EventEmitter;
 
-var INSTANCE = new EventEmitter();
+let EVENTS_RECEIVER = null;
+
+class CordovaEventEmitter extends EventEmitter {
+    /**
+     * Sets up current instance to forward emitted events to another EventEmitter
+     *   instance.
+     *
+     * @param   {EventEmitter}  [eventEmitter]  The emitter instance to forward
+     *   events to. Falsy value, when passed, disables forwarding.
+     */
+    forwardEventsTo (eventEmitter) {
+        // If no argument is specified disable events forwarding
+        if (!eventEmitter) {
+            EVENTS_RECEIVER = undefined;
+            return;
+        }
+
+        if (!(eventEmitter instanceof EventEmitter)) {
+            throw new Error('Cordova events can be redirected to another EventEmitter instance only');
+        }
+
+        // CB-10940 Skipping forwarding to self to avoid infinite recursion.
+        // This is the case when the modules are npm-linked.
+        if (this !== eventEmitter) {
+            EVENTS_RECEIVER = eventEmitter;
+        } else {
+            // Reset forwarding if we are subscribing to self
+            EVENTS_RECEIVER = undefined;
+        }
+    }
+
+    /**
+     * Sets up current instance to forward emitted events to another EventEmitter
+     *   instance.
+     *
+     * @param   {EventEmitter}  [eventEmitter]  The emitter instance to forward
+     *   events to. Falsy value, when passed, disables forwarding.
+     */
+    emit (eventName, ...args) {
+        if (EVENTS_RECEIVER) {
+            EVENTS_RECEIVER.emit(eventName, ...args);
+        }
+
+        return super.emit(eventName, ...args);
+    }
+}
+
+const INSTANCE = new CordovaEventEmitter();
 INSTANCE.setMaxListeners(20);
-var EVENTS_RECEIVER;
 
 module.exports = INSTANCE;
-
-/**
- * Sets up current instance to forward emitted events to another EventEmitter
- *   instance.
- *
- * @param   {EventEmitter}  [eventEmitter]  The emitter instance to forward
- *   events to. Falsy value, when passed, disables forwarding.
- */
-module.exports.forwardEventsTo = function (eventEmitter) {
-
-    // If no argument is specified disable events forwarding
-    if (!eventEmitter) {
-        EVENTS_RECEIVER = undefined;
-        return;
-    }
-
-    if (!(eventEmitter instanceof EventEmitter)) { throw new Error('Cordova events can be redirected to another EventEmitter instance only'); }
-
-    // CB-10940 Skipping forwarding to self to avoid infinite recursion.
-    // This is the case when the modules are npm-linked.
-    if (this !== eventEmitter) {
-        EVENTS_RECEIVER = eventEmitter;
-    } else {
-        // Reset forwarding if we are subscribing to self
-        EVENTS_RECEIVER = undefined;
-    }
-};
-
-var emit = INSTANCE.emit;
-
-/**
- * This method replaces original 'emit' method to allow events forwarding.
- *
- * @return  {eventEmitter}  Current instance to allow calls chaining, as
- *   original 'emit' does
- */
-module.exports.emit = function () {
-
-    var args = Array.prototype.slice.call(arguments);
-
-    if (EVENTS_RECEIVER) {
-        EVENTS_RECEIVER.emit.apply(EVENTS_RECEIVER, args);
-    }
-
-    return emit.apply(this, args);
-};

--- a/src/events.js
+++ b/src/events.js
@@ -19,6 +19,10 @@
 
 const EventEmitter = require('events').EventEmitter;
 
+const MAX_LISTENERS = 20;
+
+const INSTANCE_KEY = Symbol.for('org.apache.cordova.common.CordovaEvents');
+
 let EVENTS_RECEIVER = null;
 
 class CordovaEventEmitter extends EventEmitter {
@@ -66,7 +70,12 @@ class CordovaEventEmitter extends EventEmitter {
     }
 }
 
-const INSTANCE = new CordovaEventEmitter();
-INSTANCE.setMaxListeners(20);
+// This singleton instance pattern is based on the ideas from
+// https://derickbailey.com/2016/03/09/creating-a-true-singleton-in-node-js-with-es6-symbols/
+if (Object.getOwnPropertySymbols(global).indexOf(INSTANCE_KEY) === -1) {
+    const events = new CordovaEventEmitter();
+    events.setMaxListeners(MAX_LISTENERS);
+    global[INSTANCE_KEY] = events;
+}
 
-module.exports = INSTANCE;
+module.exports = global[INSTANCE_KEY];


### PR DESCRIPTION
* Refactor events object into a real ES6 class (and replace `var` with `const` & `let`)
* Use a real singleton object as described in <https://derickbailey.com/2016/03/09/creating-a-true-singleton-in-node-js-with-es6-symbols/>, in a similar fashion as done for CordovaLogger in PR #53

Using a real singleton object means that we would no longer have to follow the [cordova-common singleton rule](https://github.com/apache/cordova-coho/blob/master/docs/tools-release-process.md#cordova-common-singleton-rule) when publishing tools releases.

We may need to increase the minor version number if this change is included in cordova-common@3.

I would love to get this into the Cordova 9 release as discussed in <https://github.com/apache/cordova/issues/10>, if possible.