### PR TITLE
implement setPreference and setPlatformPreference

### DIFF
--- a/spec/ConfigParser/ConfigParser.spec.js
+++ b/spec/ConfigParser/ConfigParser.spec.js
@@ -108,6 +108,14 @@ describe('config.xml parser', function () {
             it('Test 012 : should return an empty string for a non-existing preference', function () {
                 expect(cfg.getPreference('zimzooo!')).toEqual('');
             });
+            it('should allow setting the preference', function () {
+                cfg.setPreference('orientation', 'landscape');
+                expect(cfg.getPreference('orientation')).toEqual('landscape');
+            });
+            it('should allow setting the platform specific preference', function () {
+                cfg.setPreference('android-minSdkVersion', 'android', '11');
+                expect(cfg.getPreference('android-minSdkVersion', 'android')).toEqual('11');
+            });
         });
         describe('global preference', function () {
             it('Test 013 : should return the value of a global preference', function () {
@@ -126,6 +134,13 @@ describe('config.xml parser', function () {
             });
             it('Test 017 : should return an empty string when querying with unsupported platform', function () {
                 expect(cfg.getPlatformPreference('orientation', 'foobar')).toEqual('');
+            });
+            it('should allow setting the platform specific preference', function () {
+                cfg.setPlatformPreference('orientation', 'android', 'foobar');
+                expect(cfg.getPlatformPreference('orientation', 'android')).toEqual('foobar');
+            });
+            it('should throw when setting a preference for unsupported platform', function () {
+                expect(function () { cfg.setPlatformPreference('orientation', 'foobar', 'landscape'); }).toThrow();
             });
         });
         describe('plugin', function () {

--- a/src/ConfigParser/ConfigParser.js
+++ b/src/ConfigParser/ConfigParser.js
@@ -168,6 +168,23 @@ ConfigParser.prototype = {
     getPlatformPreference: function (name, platform) {
         return findElementAttributeValue(name, this.doc.findall('./platform[@name="' + platform + '"]/preference'));
     },
+    setPlatformPreference: function (name, platform, value) {
+        const platformEl = this.doc.find('./platform[@name="' + platform + '"]');
+        if (!platformEl) {
+            throw new CordovaError('platform does not exist (received platform: ' + platform + ')');
+        }
+        const elems = this.doc.findall('./platform[@name="' + platform + '"]/preference');
+        let pref = elems.filter(function (elem) {
+            return elem.attrib.name.toLowerCase() === name.toLowerCase();
+        }).pop();
+
+        if (!pref) {
+            pref = new et.Element('preference');
+            pref.attrib.name = name;
+            platformEl.append(pref);
+        }
+        pref.attrib.value = value;
+    },
     getPreference: function (name, platform) {
 
         var platformPreference = '';
@@ -178,6 +195,18 @@ ConfigParser.prototype = {
 
         return platformPreference || this.getGlobalPreference(name);
 
+    },
+    setPreference: function (name, platform, value) {
+        if (!value) {
+            value = platform;
+            platform = undefined;
+        }
+
+        if (platform) {
+            this.setPlatformPreference(name, platform, value);
+        } else {
+            this.setGlobalPreference(name, value);
+        }
     },
     /**
      * Returns all resources for the platform specified.


### PR DESCRIPTION
### Platforms affected
None or All, it will not affect any existing code, just provides new APIs

### What does this PR do?
Support set the preference for a specific platform. Currently, only global preference is supported by the `cordova-common`.  We have used the new API to implement a hook which will update platform preference in config.xml

### What testing has been done on this change?
Four unit tests are added. The new added tests don't have `Test ${number}` prefix bc that would lead to a lot of changes in unrelated tests.
