### PR TITLE
[superspawn] Convert exceptions thrown by child_process.spawn into rejections

### DIFF
--- a/spec/superspawn.spec.js
+++ b/spec/superspawn.spec.js
@@ -89,6 +89,25 @@ describe('spawn method', function () {
             });
     });
 
+    it('Test 005 : should not throw but reject', () => {
+        if (process.platform === 'win32') {
+            pending('Test should not run on Windows');
+        }
+
+        // Our non-executable (as in no execute permission) script
+        const TEST_SCRIPT = path.join(__dirname, 'fixtures/echo-args.cmd');
+
+        let promise;
+        expect(() => { promise = superspawn.spawn(TEST_SCRIPT, []); }).not.toThrow();
+
+        return Promise.resolve(promise).then(_ => {
+            fail('Expected promise to be rejected');
+        }, err => {
+            expect(err).toEqual(jasmine.any(Error));
+            expect(err.code).toBe('EACCES');
+        });
+    });
+
     describe('operation on windows', () => {
         const TEST_SCRIPT = path.join(__dirname, 'fixtures/echo-args.cmd');
         const TEST_ARGS = [ 'install', 'foo@^1.2.3', 'c o r d o v a' ];


### PR DESCRIPTION
### Motivation and Context
At least until Node.js 8, `child_process.spawn` will throw exceptions
instead of emitting error events in certain cases (like EACCES).

### Description
To preserve the async nature of `superspawn.spawn` we have to wrap the execution in try/catch to convert the thrown exceptions into rejections.



### Testing
Added regression test for this bug. Does not run on Windows since the only case I could reproduce this was with an `EACCES` error which usually does not occur in this context there.



### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
