### PR TITLE
Add example usage of podspec declarations

### DIFF
--- a/src/PluginInfo/PluginInfo.js
+++ b/src/PluginInfo/PluginInfo.js
@@ -253,10 +253,10 @@ function PluginInfo (dirname) {
     //     <source url="https://github.com/brightcove/BrightcoveSpecs.git" />
     //     <source url="https://github.com/CocoaPods/Specs.git"/>
     //   </config>
-    //   <pods>
-    //   <pod name="PromiseKit" />
-    //   <pod name="Foobar1" spec="~> 2.0.0" />
-    //   <pod name="Foobar2" git="git@github.com:hoge/foobar1.git" />
+    //   <pods use-frameworks="true" inhibit-all-warnings="true">
+    //     <pod name="PromiseKit" />
+    //     <pod name="Foobar1" spec="~> 2.0.0" />
+    //     <pod name="Foobar2" git="git@github.com:hoge/foobar1.git" />
     //     <pod name="Foobar3" git="git@github.com:hoge/foobar2.git" branch="next" />
     //     <pod name="Foobar4" swift-version="4.1" />
     //     <pod name="Foobar5" swift-version="3.0" />


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
none


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Complementing docblock for getPodSpecs function

### Description
<!-- Describe your changes in detail -->

When trying to find more information about new `<podspec>` tag deprecating `<framework type="podspec" />` I found example usage in docblock above getPodSpecs function
However it doesn't specify how to use declarations so I've copied example from [specs fixture](https://github.com/apache/cordova-common/blob/rel/3.1.0/spec/fixtures/plugins/org.test.plugins.withcocoapods/plugin.xml#L37-L47)

Update: Example usage is also described in the [docs](https://cordova.apache.org/docs/en/9.x/plugin_ref/spec.html#podspec-ios).

### Testing
<!-- Please describe in detail how you tested your changes. -->

Change in docblock, no testing required

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
