### PR TITLE
[WIP] Migrate from istanbul to nyc coverage tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
+.nyc_output
 node_modules
-coverage
 package-lock.json

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "npm run eslint && npm run jasmine",
     "eslint": "eslint src spec",
     "jasmine": "jasmine JASMINE_CONFIG_PATH=spec/support/jasmine.json",
-    "cover": "istanbul cover --root src --print detail jasmine"
+    "cover": "nyc -x spec/ npm test"
   },
   "dependencies": {
     "ansi": "^0.3.1",
@@ -45,9 +45,9 @@
     "eslint-plugin-node": "^8.0.0",
     "eslint-plugin-promise": "^4.0.0",
     "eslint-plugin-standard": "^4.0.0",
-    "istanbul": "^0.4.5",
     "jasmine": "~3.1.0",
     "jasmine-spec-reporter": "^4.2.1",
+    "nyc": "^14.1.1",
     "osenv": "^0.1.3",
     "promise-matchers": "^0.9.6",
     "rewire": "^4.0.1"


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

All

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

It is desired to use a supported coverage tool that will be updated and should be less likely affected by security issues in the future.

### Description
<!-- Describe your changes in detail -->

See title: migrate from `istanbul` to `nyc` coverage tool, in a similar fashion to the updates in apache/cordova-lib#637, apache/cordova-lib#783, and apache/cordova-lib#784

### Testing
<!-- Please describe in detail how you tested your changes. -->

- `npm run cover` succeeds on supported Node.js versions 6, 8, and 10

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- ~~I added automated test coverage as appropriate for this change~~
- ~~Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)~~
- ~~If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))~~
- ~~I've updated the documentation if necessary~~