### PR TITLE
[WIP] Jasmine test improvements & updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "eslint-plugin-promise": "^4.0.0",
     "eslint-plugin-standard": "^4.0.0",
     "istanbul": "^0.4.5",
-    "jasmine": "~3.1.0",
+    "jasmine": "^3.4.0",
     "jasmine-spec-reporter": "^4.2.1",
     "osenv": "^0.1.3",
     "promise-matchers": "^0.9.6",

--- a/spec/superspawn.spec.js
+++ b/spec/superspawn.spec.js
@@ -127,7 +127,7 @@ describe('spawn method', function () {
 
         return promise.then(() => {
             fail('Expected promise to be rejected');
-        }).catch(err => {
+        }, err => {
             expect(err).toEqual(jasmine.any(Error));
             expect(err.code).toBe('EACCES');
         });


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

All

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

It is desired to use the latest version of `jasmine`, if possible.

While investigating some issues with jasmine@latest, I discovered some other desired improvements in `spec/PluginManager.spec.js` & `spec/superspawn.spec.js`. This includes dropping use of `q` in these 2 test scripts.

### Description
<!-- Describe your changes in detail -->

- Remove use of `q` in `spec/PluginManager.spec.js` & `spec/superspawn.spec.js` (this may be counted as a small part of the effort to drop Q ref: apache/cordova#7)
- Rewrite some test cases that were broken as of Jasmine 2 and would be broken by jasmine@latest
- jasmine@3 latest update
- other minor test updates

### Testing
<!-- Please describe in detail how you tested your changes. -->

- [x] Verified that `npm test` succeeds on Node.js versions 6, 8, and 10
- [x] Verified that Travis CI succeeds
- [x] Verified that AppVeyor CI succeeds

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- ~~I added automated test coverage as appropriate for this change~~
- ~~Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)~~
- ~~If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))~~
- ~~I've updated the documentation if necessary~~