### PR TITLE
Do not ignore AppVeyor failures on Node.js 12

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,10 +10,6 @@ environment:
   - nodejs_version: 10
   - nodejs_version: 12
 
-matrix:
-  allow_failures:
-    - nodejs_version: 12
-
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm install


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

All

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

See appveyor/ci#2921: now that AppVeyor has Node.js 12 built-in, we should not ignore failures on that Node.js version.

### Description
<!-- Describe your changes in detail -->

Remove the lines introduced in PR #68 to ignore AppVeyor failures on Node.js 12

### Testing
<!-- Please describe in detail how you tested your changes. -->

- [x] AppVeyor CI build is green on my fork
- [x] Travis CI build is green on my fork

### Checklist

- [x] I've run the tests to see all new and existing tests pass (on AppVeyor & Travis CI on my fork)
- ~~I added automated test coverage as appropriate for this change~~
- ~~Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)~~
- ~~If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))~~
- ~~I've updated the documentation if necessary~~
