### PR TITLE
(windows) Add .jsproj as file extension for XML files to ConfigFile

### DIFF
--- a/src/ConfigChanges/ConfigFile.js
+++ b/src/ConfigChanges/ConfigFile.js
@@ -71,7 +71,7 @@ function ConfigFile_load () {
     var ext = path.extname(filepath);
     // Windows8 uses an appxmanifest, and wp8 will likely use
     // the same in a future release
-    if (ext === '.xml' || ext === '.appxmanifest' || ext === '.storyboard') {
+    if (ext === '.xml' || ext === '.appxmanifest' || ext === '.storyboard' || ext === '.jsproj') {
         self.type = 'xml';
         self.data = modules.xml_helpers.parseElementtreeSync(filepath);
     } else {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Windows


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #62


### Description
<!-- Describe your changes in detail -->
Added the file extension `.jsproj` to the allowed extensions for XML files in order to modify such files using the `config-file` tag in the `config.xml`


### Testing
<!-- Please describe in detail how you tested your changes. -->
1. Add the following markup to the `config.xml` inside the `<platform name="windows">` tag:

```
<config-file parent="/Project/PropertyGroup" target="CordovaApp.Windows10.jsproj" versions="10">
    <Test>Hello</Test>
</config-file>
```

2. Run `cordova build windows`

_Result without this change:_
The build is aborted with the error message: `malformed document. First element should be <plist>`

_Result with this change:_
The build completes without errors and the `<Test>Hello</Test>` Tag is written to the `CordovaApp.Windows10.jsproj` file.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
