### PR TITLE
remove no-throw-literal lint exception not needed

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -7,7 +7,6 @@ rules:
   camelcase: off
   padded-blocks: off
   operator-linebreak: off
-  no-throw-literal: off
   no-unused-vars:
     - error
     - args: after-used


### PR DESCRIPTION
UPDATED:

- Updated the title
- keeping the custom `no-unused-vars` entry, as requested in the discussion below
- rebased on `master` with force-push after merge of PR #83

As there is desire to keep the custom `no-unused-vars` entry, there seems to be only one exception that we can remove without updating the code. This is why I updated the title and force-pushed the change with the updated commit message.