### PR TITLE
General cleanup with eslint updates

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -5,7 +5,6 @@ rules:
     - error
     - 4
   camelcase: off
-  padded-blocks: off
   no-unused-vars:
     - error
     - args: after-used

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
   },
   "devDependencies": {
     "eslint": "^5.0.0",
-    "eslint-config-semistandard": "^13.0.0",
-    "eslint-config-standard": "^12.0.0",
+    "eslint-config-semistandard": "^14.0.0",
+    "eslint-config-standard": "^13.0.1",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-node": "^8.0.0",
     "eslint-plugin-promise": "^4.0.0",

--- a/spec/ConfigChanges/ConfigChanges.spec.js
+++ b/spec/ConfigChanges/ConfigChanges.spec.js
@@ -87,10 +87,10 @@ describe('config-changes module', function () {
             });
             it('Test 002 : should append specified plugin with any variables to platform.json', function () {
                 var platformJson = new PlatformJson(null, 'android', null);
-                platformJson.addInstalledPluginToPrepareQueue('org.test.plugins.dummyplugin', { 'dude': 'man' });
+                platformJson.addInstalledPluginToPrepareQueue('org.test.plugins.dummyplugin', { dude: 'man' });
                 var json = platformJson.root;
                 expect(json.prepare_queue.installed[0].plugin).toEqual('org.test.plugins.dummyplugin');
-                expect(json.prepare_queue.installed[0].vars).toEqual({ 'dude': 'man' });
+                expect(json.prepare_queue.installed[0].vars).toEqual({ dude: 'man' });
             });
         });
 
@@ -116,7 +116,7 @@ describe('config-changes module', function () {
             var filepath = path.join(plugins_dir, 'android.json');
             var json = {
                 prepare_queue: { installed: [], uninstalled: [] },
-                config_munge: { files: { 'some_file': { parents: { 'some_parent': [{ 'xml': 'some_change', 'count': 1 }] } } } },
+                config_munge: { files: { some_file: { parents: { some_parent: [{ xml: 'some_change', count: 1 }] } } } },
                 installed_plugins: {},
                 dependent_plugins: {}
             };
@@ -208,7 +208,7 @@ describe('config-changes module', function () {
         it('Test 014 : should generate config munges for queued plugins', function () {
             fs.copySync(android_two_project, temp);
             var platformJson = PlatformJson.load(plugins_dir, 'android');
-            platformJson.root.prepare_queue.installed = [{ 'plugin': 'org.test.plugins.dummyplugin', 'vars': {} }];
+            platformJson.root.prepare_queue.installed = [{ plugin: 'org.test.plugins.dummyplugin', vars: {} }];
             var munger = new configChanges.PlatformMunger('android', temp, platformJson, pluginInfoProvider);
             var spy = spyOn(munger, 'generate_plugin_config_munge').and.returnValue({});
             munger.process(plugins_dir);
@@ -221,7 +221,7 @@ describe('config-changes module', function () {
                 });
                 it('Test 015 : should call graftXML for every new config munge it introduces (every leaf in config munge that does not exist)', function () {
                     var platformJson = PlatformJson.load(plugins_dir, 'android');
-                    platformJson.root.prepare_queue.installed = [{ 'plugin': 'org.test.plugins.dummyplugin', 'vars': {} }];
+                    platformJson.root.prepare_queue.installed = [{ plugin: 'org.test.plugins.dummyplugin', vars: {} }];
 
                     var spy = spyOn(xml_helpers, 'graftXML').and.returnValue(true);
 
@@ -558,7 +558,7 @@ describe('config-changes module', function () {
                 install_plugin(varplugin);
 
                 var platformJson = PlatformJson.load(plugins_dir, 'android');
-                platformJson.addInstalledPluginToPrepareQueue('com.adobe.vars', { 'API_KEY': 'hi' }, true);
+                platformJson.addInstalledPluginToPrepareQueue('com.adobe.vars', { API_KEY: 'hi' }, true);
 
                 var munger = new configChanges.PlatformMunger('android', temp, platformJson, pluginInfoProvider);
                 munger.process(plugins_dir);
@@ -595,7 +595,7 @@ describe('config-changes module', function () {
 
                 // Run through an "install"
                 var platformJson = PlatformJson.load(plugins_dir, 'android');
-                platformJson.addInstalledPluginToPrepareQueue('com.adobe.vars', { 'API_KEY': 'canucks' });
+                platformJson.addInstalledPluginToPrepareQueue('com.adobe.vars', { API_KEY: 'canucks' });
                 var munger = new configChanges.PlatformMunger('android', temp, platformJson, pluginInfoProvider);
                 munger.process(plugins_dir);
 
@@ -651,7 +651,7 @@ describe('config-changes module', function () {
 
                 // install the var plugin
                 var platformJson = PlatformJson.load(plugins_dir, 'android');
-                platformJson.addInstalledPluginToPrepareQueue('com.adobe.vars', { 'API_KEY': 'eat my shorts' });
+                platformJson.addInstalledPluginToPrepareQueue('com.adobe.vars', { API_KEY: 'eat my shorts' });
                 var munger = new configChanges.PlatformMunger('android', temp, platformJson, pluginInfoProvider);
                 munger.process(plugins_dir);
 

--- a/spec/ConfigChanges/ConfigChanges.spec.js
+++ b/spec/ConfigChanges/ConfigChanges.spec.js
@@ -413,7 +413,6 @@ describe('config-changes module', function () {
                     expect(sdk.attrib['android:targetSdkVersion']).toEqual('24');
                     expect(sdk.attrib['android:minSdkVersion']).toEqual('14');
                     expect(sdk.attrib['android:maxSdkVersion']).toBeUndefined();
-
                 });
                 it('should append new children to XML document tree', function () {
                     var configfile_cfg = new ConfigParser(configfile_xml);
@@ -484,7 +483,6 @@ describe('config-changes module', function () {
                     var munger = new configChanges.PlatformMunger('android', temp, platformJson, pluginInfoProvider);
                     munger.add_config_changes(cfg, true);
                     expect(function () { munger.process(plugins_dir); }).toThrow(new Error('org.test.editconfigtest_two cannot be added. <edit-config> changes in this plugin conflicts with <edit-config> changes in config.xml. Conflicts must be resolved before plugin can be added.'));
-
                 });
             });
             describe('of plist config files', function () {

--- a/spec/ConfigChanges/ConfigFile.spec.js
+++ b/spec/ConfigChanges/ConfigFile.spec.js
@@ -22,7 +22,6 @@ var path = require('path');
 var projectDir = path.join('project_dir', 'app', 'src', 'main');
 
 describe('ConfigFile tests', function () {
-
     beforeEach(function () {
         spyOn(configFile, 'isBinaryPlist').and.callThrough();
     });

--- a/spec/CordovaLogger.spec.js
+++ b/spec/CordovaLogger.spec.js
@@ -43,7 +43,6 @@ describe('CordovaLogger class', function () {
     });
 
     describe('instance', function () {
-
         var logger;
 
         beforeEach(function () {
@@ -92,7 +91,6 @@ describe('CordovaLogger class', function () {
             });
 
             it('Test 009 : should attach corresponding listeners to supplied emitter', function () {
-
                 var eventNamesExclusions = {
                     log: 'normal',
                     warning: 'warn'
@@ -110,7 +108,6 @@ describe('CordovaLogger class', function () {
         });
 
         describe('log method', function () {
-
             function CursorSpy (name) {
                 var cursorMethods = ['reset', 'write'];
                 var spy = jasmine.createSpyObj(name, cursorMethods);

--- a/spec/FileUpdater.spec.js
+++ b/spec/FileUpdater.spec.js
@@ -120,7 +120,6 @@ var testFileStats3 = mockFileStats(now);
 var nullLogger = function () {};
 
 describe('FileUpdater class', function () {
-
     beforeEach(function () {
         FileUpdater.updatePathWithStatsCalls = [];
         FileUpdater.updatePathWithStatsResult = true;
@@ -759,6 +758,5 @@ describe('FileUpdater class', function () {
                 testTargetDir,
                 null);
         });
-
     });
 });

--- a/spec/PlatformJson.spec.js
+++ b/spec/PlatformJson.spec.js
@@ -84,7 +84,6 @@ describe('PlatformJson class', function () {
             });
 
             it('Test 007 : should remove plugin modules from "root.modules" array based on file path', function () {
-
                 var pluginPaths = [
                     'plugins/fakeId/www/fakeModule.js',
                     'plugins/otherPlugin/www/module1.js',

--- a/spec/PluginManager.spec.js
+++ b/spec/PluginManager.spec.js
@@ -37,7 +37,6 @@ var FAKE_LOCATIONS = {
 };
 
 describe('PluginManager class', function () {
-
     beforeEach(function () {
         spyOn(ConfigChanges, 'PlatformMunger');
         spyOn(fs, 'outputJsonSync');

--- a/spec/plist-helpers.spec.js
+++ b/spec/plist-helpers.spec.js
@@ -58,19 +58,19 @@ describe('prunePLIST', function () {
 });
 
 describe('plistGraft', function () {
-    let doc = {
+    const doc = {
         'keychain-access-groups': [
             '$(AppIdentifierPrefix)io.cordova.hellocordova',
             '$(AppIdentifierPrefix)com.example.mylib'
         ]
     };
 
-    let xml = '<array>' +
+    const xml = '<array>' +
                 '<string>$(AppIdentifierPrefix)io.cordova.hellocordova</string>' +
                 '<string>$(AppIdentifierPrefix)com.example.mylib</string>' +
               '</array>';
 
-    let selector = 'keychain-access-groups';
+    const selector = 'keychain-access-groups';
 
     it('Test 01: should not mangle existing plist entries', () => {
         var graftStatus = plistHelpers.graftPLIST(doc, xml, selector);

--- a/spec/superspawn.spec.js
+++ b/spec/superspawn.spec.js
@@ -124,5 +124,4 @@ describe('spawn method', function () {
             });
         });
     });
-
 });

--- a/spec/superspawn.spec.js
+++ b/spec/superspawn.spec.js
@@ -41,7 +41,7 @@ describe('spawn method', function () {
         return superspawn.spawn(LS, [], { stdio: 'pipe' })
             .progress(progressSpy)
             .then(function () {
-                expect(progressSpy).toHaveBeenCalledWith({ 'stdout': jasmine.any(String) });
+                expect(progressSpy).toHaveBeenCalledWith({ stdout: jasmine.any(String) });
             });
     });
 
@@ -51,7 +51,7 @@ describe('spawn method', function () {
             .then(() => {
                 fail('Expected promise to be rejected');
             }, () => {
-                expect(progressSpy).toHaveBeenCalledWith({ 'stderr': jasmine.any(String) });
+                expect(progressSpy).toHaveBeenCalledWith({ stderr: jasmine.any(String) });
             });
     });
 
@@ -112,7 +112,7 @@ describe('spawn method', function () {
 
     describe('operation on windows', () => {
         const TEST_SCRIPT = path.join(__dirname, 'fixtures/echo-args.cmd');
-        const TEST_ARGS = [ 'install', 'foo@^1.2.3', 'c o r d o v a' ];
+        const TEST_ARGS = ['install', 'foo@^1.2.3', 'c o r d o v a'];
 
         it('should escape arguments if `cmd` is not an *.exe', () => {
             if (process.platform !== 'win32') {

--- a/spec/util/xml-helpers.spec.js
+++ b/spec/util/xml-helpers.spec.js
@@ -434,7 +434,6 @@ describe('xml-helpers', function () {
             xml_helpers.mergeXml(testXml, dstXml, '', true);
             testElements = dstXml.findall('access');
             expect(testElements.length).toEqual(2);
-
         });
 
         it('Test 042 : should remove duplicate preferences (by name attribute value)', function () {

--- a/src/ConfigChanges/ConfigChanges.js
+++ b/src/ConfigChanges/ConfigChanges.js
@@ -220,7 +220,6 @@ function add_config_changes (config, should_increment) {
                 // skip no chnages
                 return changes.filter(function (x) { return isConflictingInfo.noChanges.indexOf(x) === -1; });
             }
-
         }
         return changes;
     })(changes);
@@ -443,11 +442,9 @@ function is_conflicting (editchanges, config_munge, self, force) {
                                 mungeutil.deep_add(conflictingMunge, change_file, conflictingParent, target_elem);
                             });
                         }
-
                     } else {
                         // plugin cannot overwrite other plugin changes without --force
                         conflictingPlugin = target[0].plugin;
-
                     }
                 }
             }

--- a/src/ConfigParser/ConfigParser.js
+++ b/src/ConfigParser/ConfigParser.js
@@ -74,7 +74,6 @@ function getCordovaNamespacePrefix (doc) {
  * @return {String}
  */
 function findElementAttributeValue (attributeName, elems) {
-
     elems = Array.isArray(elems) ? elems : [elems];
 
     var value = elems.filter(function (elem) {
@@ -186,7 +185,6 @@ ConfigParser.prototype = {
         pref.attrib.value = value;
     },
     getPreference: function (name, platform) {
-
         var platformPreference = '';
 
         if (platform) {
@@ -194,7 +192,6 @@ ConfigParser.prototype = {
         }
 
         return platformPreference || this.getGlobalPreference(name);
-
     },
     setPreference: function (name, platform, value) {
         if (!value) {

--- a/src/ConfigParser/ConfigParser.js
+++ b/src/ConfigParser/ConfigParser.js
@@ -75,7 +75,7 @@ function getCordovaNamespacePrefix (doc) {
  */
 function findElementAttributeValue (attributeName, elems) {
 
-    elems = Array.isArray(elems) ? elems : [ elems ];
+    elems = Array.isArray(elems) ? elems : [elems];
 
     var value = elems.filter(function (elem) {
         return elem.attrib.name.toLowerCase() === attributeName.toLowerCase();
@@ -505,8 +505,8 @@ ConfigParser.prototype = {
         return engines.map(function (engine) {
             var spec = engine.attrib.spec || engine.attrib.version;
             return {
-                'name': engine.attrib.name,
-                'spec': spec || null
+                name: engine.attrib.name,
+                spec: spec || null
             };
         });
     },
@@ -523,14 +523,14 @@ ConfigParser.prototype = {
             var allows_local_networking = access.attrib['allows-local-networking']; /* Boolean */
 
             return {
-                'origin': access.attrib.origin,
-                'minimum_tls_version': minimum_tls_version,
-                'requires_forward_secrecy': requires_forward_secrecy,
-                'requires_certificate_transparency': requires_certificate_transparency,
-                'allows_arbitrary_loads_in_web_content': allows_arbitrary_loads_in_web_content,
-                'allows_arbitrary_loads_in_media': allows_arbitrary_loads_in_media,
-                'allows_arbitrary_loads_for_media': allows_arbitrary_loads_for_media,
-                'allows_local_networking': allows_local_networking
+                origin: access.attrib.origin,
+                minimum_tls_version: minimum_tls_version,
+                requires_forward_secrecy: requires_forward_secrecy,
+                requires_certificate_transparency: requires_certificate_transparency,
+                allows_arbitrary_loads_in_web_content: allows_arbitrary_loads_in_web_content,
+                allows_arbitrary_loads_in_media: allows_arbitrary_loads_in_media,
+                allows_arbitrary_loads_for_media: allows_arbitrary_loads_for_media,
+                allows_local_networking: allows_local_networking
             };
         });
     },
@@ -543,10 +543,10 @@ ConfigParser.prototype = {
             var requires_certificate_transparency = allow_navigation.attrib['requires-certificate-transparency']; /* Boolean */
 
             return {
-                'href': allow_navigation.attrib.href,
-                'minimum_tls_version': minimum_tls_version,
-                'requires_forward_secrecy': requires_forward_secrecy,
-                'requires_certificate_transparency': requires_certificate_transparency
+                href: allow_navigation.attrib.href,
+                minimum_tls_version: minimum_tls_version,
+                requires_forward_secrecy: requires_forward_secrecy,
+                requires_certificate_transparency: requires_certificate_transparency
             };
         });
     },
@@ -555,7 +555,7 @@ ConfigParser.prototype = {
         var allow_intents = this.doc.findall('./allow-intent');
         return allow_intents.map(function (allow_intent) {
             return {
-                'href': allow_intent.attrib.href
+                href: allow_intent.attrib.href
             };
         });
     },

--- a/src/CordovaError/CordovaError.js
+++ b/src/CordovaError/CordovaError.js
@@ -49,11 +49,9 @@ CordovaError.EXTERNAL_TOOL_ERROR = 1;
  * @returns {string} Error code string name
  */
 CordovaError.prototype.getErrorCodeName = function () {
-    for (var key in CordovaError) {
-        if (CordovaError.hasOwnProperty(key)) {
-            if (CordovaError[key] === this.code) {
-                return key;
-            }
+    for (const key of Object.keys(CordovaError)) {
+        if (CordovaError[key] === this.code) {
+            return key;
         }
     }
 };

--- a/src/CordovaLogger.js
+++ b/src/CordovaLogger.js
@@ -37,10 +37,15 @@ const INSTANCE_KEY = Symbol.for('org.apache.cordova.common.CordovaLogger');
 class CordovaLogger {
     // Encapsulate the default logging level values with constants:
     static get VERBOSE () { return 'verbose'; }
+
     static get NORMAL () { return 'normal'; }
+
     static get WARN () { return 'warn'; }
+
     static get INFO () { return 'info'; }
+
     static get ERROR () { return 'error'; }
+
     static get RESULTS () { return 'results'; }
 
     /**

--- a/src/FileUpdater.js
+++ b/src/FileUpdater.js
@@ -244,7 +244,7 @@ function updatePaths (pathMap, options, log) {
  */
 function mergeAndUpdateDir (sourceDirs, targetDir, options, log) {
     if (sourceDirs && typeof sourceDirs === 'string') {
-        sourceDirs = [ sourceDirs ];
+        sourceDirs = [sourceDirs];
     } else if (!Array.isArray(sourceDirs)) {
         throw new Error('A source directory path or array of paths is required.');
     }
@@ -257,16 +257,16 @@ function mergeAndUpdateDir (sourceDirs, targetDir, options, log) {
 
     var rootDir = (options && options.rootDir) || '';
 
-    var include = (options && options.include) || [ '**' ];
+    var include = (options && options.include) || ['**'];
     if (typeof include === 'string') {
-        include = [ include ];
+        include = [include];
     } else if (!Array.isArray(include)) {
         throw new Error('Include parameter must be a glob string or array of glob strings.');
     }
 
     var exclude = (options && options.exclude) || [];
     if (typeof exclude === 'string') {
-        exclude = [ exclude ];
+        exclude = [exclude];
     } else if (!Array.isArray(exclude)) {
         throw new Error('Exclude parameter must be a glob string or array of glob strings.');
     }

--- a/src/PlatformJson.js
+++ b/src/PlatformJson.js
@@ -89,7 +89,6 @@ PlatformJson.prototype.addPlugin = function (pluginId, variables, isTopLevel) {
  * @returns {this} Current PlatformJson instance to allow calls chaining
  */
 PlatformJson.prototype.addPluginMetadata = function (pluginInfo) {
-
     var installedModules = this.root.modules || [];
 
     var installedPaths = installedModules.map(function (installedModule) {
@@ -242,7 +241,6 @@ function fix_munge (root) {
  * @param (JsModule|Object)  jsModule  A js-module entry from PluginInfo class to generate metadata for
  */
 function ModuleMetadata (pluginId, jsModule) {
-
     if (!pluginId) throw new TypeError('pluginId argument must be a valid plugin id');
     if (!jsModule.src && !jsModule.name) throw new TypeError('jsModule argument must contain src or/and name properties');
 

--- a/src/PlatformJson.js
+++ b/src/PlatformJson.js
@@ -153,11 +153,11 @@ PlatformJson.prototype.removePluginMetadata = function (pluginInfo) {
 };
 
 PlatformJson.prototype.addInstalledPluginToPrepareQueue = function (pluginDirName, vars, is_top_level, force) {
-    this.root.prepare_queue.installed.push({ 'plugin': pluginDirName, 'vars': vars, 'topLevel': is_top_level, 'force': force });
+    this.root.prepare_queue.installed.push({ plugin: pluginDirName, vars: vars, topLevel: is_top_level, force: force });
 };
 
 PlatformJson.prototype.addUninstalledPluginToPrepareQueue = function (pluginId, is_top_level) {
-    this.root.prepare_queue.uninstalled.push({ 'plugin': pluginId, 'id': pluginId, 'topLevel': is_top_level });
+    this.root.prepare_queue.uninstalled.push({ plugin: pluginId, id: pluginId, topLevel: is_top_level });
 };
 
 /**

--- a/src/superspawn.js
+++ b/src/superspawn.js
@@ -103,7 +103,7 @@ exports.spawn = function (cmd, args, opts) {
         child.stdout.setEncoding('utf8');
         child.stdout.on('data', function (data) {
             capturedOut += data;
-            d.notify({ 'stdout': data });
+            d.notify({ stdout: data });
         });
     }
 
@@ -111,7 +111,7 @@ exports.spawn = function (cmd, args, opts) {
         child.stderr.setEncoding('utf8');
         child.stderr.on('data', function (data) {
             capturedErr += data;
-            d.notify({ 'stderr': data });
+            d.notify({ stderr: data });
         });
     }
 

--- a/src/util/addProperty.js
+++ b/src/util/addProperty.js
@@ -18,7 +18,6 @@
 */
 
 module.exports = function addProperty (module, property, modulePath, obj) {
-
     obj = obj || module.exports;
     // Add properties as getter to delay load the modules on first invocation
     Object.defineProperty(obj, property, {

--- a/src/util/xml-helpers.js
+++ b/src/util/xml-helpers.js
@@ -172,7 +172,6 @@ module.exports = {
         });
 
         return true;
-
     },
 
     parseElementtreeSync: function (filename) {

--- a/src/util/xml-helpers.js
+++ b/src/util/xml-helpers.js
@@ -293,7 +293,7 @@ function mergeXml (src, dest, platform, clobber) {
     function removeDuplicatePreferences (xml) {
         // reduce preference tags to a hashtable to remove dupes
         var prefHash = xml.findall('preference[@name][@value]').reduce(function (previousValue, currentValue) {
-            previousValue[ currentValue.attrib.name ] = currentValue.attrib.value;
+            previousValue[currentValue.attrib.name] = currentValue.attrib.value;
             return previousValue;
         }, {});
 


### PR DESCRIPTION
UPDATED after review and discussion:

- ~~merge changes from PR #81 to remove standard eslint exceptions from `.eslint.yml` that are not needed~~
- manual cleanup fix for `no-prototype-builtins` (as needed by new (semi)standard eslint package updates)
- eslint-config-semistandard@14 & eslint-config-standard@13 updates with automatic cleanup fixes (since the `prefer-const` & `quote-props` eslint rules are now enabled)
- automatic eslint cleanup fixes for `padded-blocks` that is no longer kept as an exception

I tried to keep these changes split into separate commits in a semi-sensical manner. I think it would be _a little_ too much to put all these changes into a single commit. I am _now_ proposing _the most important_ changes in _this_ PR for discussion, _with some apparently controversial changes now split into separate PRs_.

My objective is to keep the number of (semi)standard eslint exceptions to a bare minimum.