### PR TITLE
eslint cleanup fixes: operator-linebreak

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -6,7 +6,6 @@ rules:
     - 4
   camelcase: off
   padded-blocks: off
-  operator-linebreak: off
   no-throw-literal: off
   no-unused-vars:
     - error

--- a/src/ConfigChanges/ConfigChanges.js
+++ b/src/ConfigChanges/ConfigChanges.js
@@ -90,9 +90,9 @@ PlatformMunger.prototype.remove_plugin_changes = remove_plugin_changes;
 function remove_plugin_changes (pluginInfo, is_top_level) {
     var self = this;
     var platform_config = self.platformJson.root;
-    var plugin_vars = is_top_level ?
-        platform_config.installed_plugins[pluginInfo.id] :
-        platform_config.dependent_plugins[pluginInfo.id];
+    var plugin_vars = is_top_level
+        ? platform_config.installed_plugins[pluginInfo.id]
+        : platform_config.dependent_plugins[pluginInfo.id];
     var edit_config_changes = null;
     if (pluginInfo.getEditConfigs) {
         edit_config_changes = pluginInfo.getEditConfigs(self.platform);

--- a/src/ConfigChanges/ConfigFile.js
+++ b/src/ConfigChanges/ConfigFile.js
@@ -79,9 +79,9 @@ function ConfigFile_load () {
         //       We always write out text plist, not binary.
         //       Do we still need to support binary plist?
         //       If yes, use plist.parseStringSync() and read the file once.
-        self.data = isBinaryPlist(filepath) ?
-            modules.bplist.parseBuffer(fs.readFileSync(filepath))[0] :
-            modules.plist.parse(fs.readFileSync(filepath, 'utf8'));
+        self.data = isBinaryPlist(filepath)
+            ? modules.bplist.parseBuffer(fs.readFileSync(filepath))[0]
+            : modules.plist.parse(fs.readFileSync(filepath, 'utf8'));
     }
 }
 

--- a/src/PlatformJson.js
+++ b/src/PlatformJson.js
@@ -72,9 +72,9 @@ PlatformJson.prototype.isPluginInstalled = function (pluginId) {
 };
 
 PlatformJson.prototype.addPlugin = function (pluginId, variables, isTopLevel) {
-    var pluginsList = isTopLevel ?
-        this.root.installed_plugins :
-        this.root.dependent_plugins;
+    var pluginsList = isTopLevel
+        ? this.root.installed_plugins
+        : this.root.dependent_plugins;
 
     pluginsList[pluginId] = variables;
 
@@ -114,9 +114,9 @@ PlatformJson.prototype.addPluginMetadata = function (pluginInfo) {
 };
 
 PlatformJson.prototype.removePlugin = function (pluginId, isTopLevel) {
-    var pluginsList = isTopLevel ?
-        this.root.installed_plugins :
-        this.root.dependent_plugins;
+    var pluginsList = isTopLevel
+        ? this.root.installed_plugins
+        : this.root.dependent_plugins;
 
     delete pluginsList[pluginId];
 

--- a/src/PluginInfo/PluginInfo.js
+++ b/src/PluginInfo/PluginInfo.js
@@ -68,9 +68,9 @@ function PluginInfo (dirname) {
 
         if (!src || !target) {
             var msg =
-                'Malformed <asset> tag. Both "src" and "target" attributes'
-                + 'must be specified in\n'
-                + self.filepath
+                'Malformed <asset> tag. Both "src" and "target" attributes' +
+                'must be specified in\n' +
+                self.filepath
                 ;
             throw new Error(msg);
         }
@@ -113,8 +113,8 @@ function PluginInfo (dirname) {
 
         if (!dep.id) {
             var msg =
-                '<dependency> tag is missing id attribute in '
-                + self.filepath
+                '<dependency> tag is missing id attribute in ' +
+                self.filepath
                 ;
             throw new CordovaError(msg);
         }


### PR DESCRIPTION
- remove `operator-linebreak` exception from `.eslintrc.yml`
- reformat ternary expresssions according to (semi)standard
- reformat error message expressions according to (semi)standard

as done by the following command, with no `operator-linebreak` exception enabled:

    npm run eslint -- --fix

I am breaking this proposal out of PR #82 due to its seemingly controversial nature.

I would really favor applying these fixes, which I think are consistent with both (semi)standard and Prettier styling.