### PR TITLE
chore: drop node 6 and 8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ git:
   depth: 10
 
 node_js:
-  - 6
-  - 8
   - 10
   - 12
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,8 +5,6 @@ shallow_clone: true
 
 environment:
   matrix:
-  - nodejs_version: 6
-  - nodejs_version: 8
   - nodejs_version: 10
   - nodejs_version: 12
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "main": "cordova-common.js",
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "test": "npm run eslint && npm run jasmine",


### PR DESCRIPTION
### Motivation and Context

* Follow inline with Node Support
* Prepare for next major
* https://github.com/apache/cordova/issues/79

### Description

* Removes Node 6 and 8 from CI Testing Services
* Bump `engines.node` to `>=10` in `package.json`

### Testing

- `npm t`
- CI services continue to pass

### Checklist

- [x] I've run the tests to see all new and existing tests pass
