### PR TITLE
Re-apply fix for failing CordovaError test

### DIFF
--- a/spec/CordovaError/CordovaError.spec.js
+++ b/spec/CordovaError/CordovaError.spec.js
@@ -34,7 +34,7 @@ describe('CordovaError class', function () {
     it('Test 003 : toString works', function () {
         var error003_1 = new CordovaError('error', 0);
         expect(error003_1.toString(false)).toEqual('error');
-        expect(error003_1.toString(true).substring(0, 12)).toEqual('CordovaError');
+        expect(error003_1.toString(true)).toContain(error003_1.stack);
         var error003_2 = new CordovaError('error', 1);
         expect(error003_2.toString(false)).toEqual('External tool failed with an error: error');
     });


### PR DESCRIPTION
This fix was first introduced in #65 and erroneously reverted by #89.

Fixes #49