### PR TITLE
fix: PluginInfoProvider for scoped plugins

### DIFF
--- a/spec/PluginInfo/PluginInfoProvider.spec.js
+++ b/spec/PluginInfo/PluginInfoProvider.spec.js
@@ -28,6 +28,10 @@ describe('PluginInfoProvider', function () {
             var pluginInfoProvider = new PluginInfoProvider();
             var plugins = pluginInfoProvider.getAllWithinSearchPath(pluginsDir);
             expect(plugins.length).not.toBe(0);
+            expect(plugins).toContain(jasmine.objectContaining({
+                id: 'org.test.scoped',
+                dir: path.join(pluginsDir, '@scope/test')
+            }));
         });
     });
 });

--- a/spec/fixtures/plugins/@scope/test/plugin.xml
+++ b/spec/fixtures/plugins/@scope/test/plugin.xml
@@ -1,0 +1,1 @@
+<plugin id="org.test.scoped" />

--- a/src/PluginInfo/PluginInfoProvider.js
+++ b/src/PluginInfo/PluginInfoProvider.js
@@ -69,7 +69,7 @@ function getAllHelper (absPath, provider) {
         cwd: absPath,
         nodir: true,
         absolute: true
-    });
+    }).map(path.normalize);
 
     return pluginXmlPaths.map(pluginXmlPath => {
         try {


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This is the `cordova-common` part of PRs apache/cordova-lib#602 and apache/cordova-lib#680 whose goal is to support scoped npm packages as plugins the same way as regular packages. 

### Description
<!-- Describe your changes in detail -->
The key difference with scoped packages is that they nested within their `@scope/` directory in the `plugins/` directory. This commit changes `PluginInfoProvider` to honor that fact.


### Testing
<!-- Please describe in detail how you tested your changes. -->
I added an expectation to the unit tests of `PluginInfoProvider`.