### PR TITLE
chore: drop q where possible

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "lodash.isobject": "^3.0.2",
     "lodash.zip": "^4.2.0",
     "plist": "^3.0.6",
+    "q": "^1.5.1",
     "read-chunk": "^3.2.0",
     "strip-bom": "^4.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "lodash.isobject": "^3.0.2",
     "lodash.zip": "^4.2.0",
     "plist": "^3.0.6",
-    "q": "^1.5.1",
     "read-chunk": "^3.2.0",
     "strip-bom": "^4.0.0"
   },

--- a/spec/PluginManager.spec.js
+++ b/spec/PluginManager.spec.js
@@ -17,7 +17,6 @@
     under the License.
 */
 
-const Q = require('q');
 const fs = require('fs-extra');
 const path = require('path');
 const rewire = require('rewire');
@@ -61,7 +60,7 @@ describe('PluginManager class', function () {
             FAKE_PROJECT = jasmine.createSpyObj('project', ['getInstaller', 'getUninstaller', 'write']);
             manager = new PluginManager('windows', FAKE_LOCATIONS, FAKE_PROJECT);
             actions = jasmine.createSpyObj('actions', ['createAction', 'push', 'process']);
-            actions.process.and.returnValue(Q.resolve());
+            actions.process.and.returnValue(Promise.resolve());
             PluginManager.__set__('ActionStack', function () { return actions; });
         });
 

--- a/src/ActionStack.js
+++ b/src/ActionStack.js
@@ -18,7 +18,6 @@
 */
 
 const events = require('./events');
-const Q = require('q');
 
 class ActionStack {
     constructor () {
@@ -72,13 +71,13 @@ class ActionStack {
                     }
                 }
                 e.message = issue + e.message;
-                return Q.reject(e);
+                return Promise.reject(e);
             }
             this.completed.push(action);
         }
         events.emit('verbose', 'Action stack processing complete.');
 
-        return Q();
+        return Promise.resolve();
     }
 }
 

--- a/src/PluginManager.js
+++ b/src/PluginManager.js
@@ -17,7 +17,6 @@
        under the License.
 */
 
-const Q = require('q');
 const fs = require('fs-extra');
 const path = require('path');
 
@@ -80,9 +79,9 @@ class PluginManager {
      * @returns {Promise} Returns a Q promise, either resolved in case of success, rejected otherwise.
      */
     doOperation (operation, plugin, options) {
-        if (operation !== PluginManager.INSTALL && operation !== PluginManager.UNINSTALL) { return Q.reject(new CordovaError('The parameter is incorrect. The opeation must be either "add" or "remove"')); }
+        if (operation !== PluginManager.INSTALL && operation !== PluginManager.UNINSTALL) { return Promise.reject(new CordovaError('The parameter is incorrect. The opeation must be either "add" or "remove"')); }
 
-        if (!plugin || plugin.constructor.name !== 'PluginInfo') { return Q.reject(new CordovaError('The parameter is incorrect. The first parameter should be a PluginInfo instance')); }
+        if (!plugin || plugin.constructor.name !== 'PluginInfo') { return Promise.reject(new CordovaError('The parameter is incorrect. The first parameter should be a PluginInfo instance')); }
 
         // Set default to empty object to play safe when accesing properties
         options = options || {};

--- a/src/PluginManager.js
+++ b/src/PluginManager.js
@@ -76,7 +76,7 @@ class PluginManager {
      * @param {Object} [options={}] An installation options. It is expected but is not necessary
      *   that options would contain 'variables' inner object with 'PACKAGE_NAME' field set by caller.
      *
-     * @returns {Promise} Returns a Q promise, either resolved in case of success, rejected otherwise.
+     * @returns {Promise}
      */
     doOperation (operation, plugin, options) {
         if (operation !== PluginManager.INSTALL && operation !== PluginManager.UNINSTALL) { return Promise.reject(new CordovaError('The parameter is incorrect. The opeation must be either "add" or "remove"')); }


### PR DESCRIPTION
### Motivation, Context & Description

- Replace `q` module with native promises https://github.com/apache/cordova/issues/7
- Closes #76

`superspawn` is not removed and still uses `Q` for `progress` & `notify`.

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
