### PR TITLE
chore: replace instanbul w/ nyc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 coverage
 package-lock.json
+.nyc_output

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 spec
 coverage
+.nyc_output

--- a/.npmignore
+++ b/.npmignore
@@ -2,4 +2,3 @@
 appveyor.yml
 spec
 coverage
-.nyc_output

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "npm run eslint && npm run jasmine",
     "eslint": "eslint src spec",
     "jasmine": "jasmine JASMINE_CONFIG_PATH=spec/support/jasmine.json",
-    "cover": "istanbul cover --root src --print detail jasmine"
+    "cover": "nyc npm run jasmine"
   },
   "dependencies": {
     "ansi": "^0.3.1",
@@ -45,12 +45,22 @@
     "eslint-plugin-node": "^8.0.0",
     "eslint-plugin-promise": "^4.0.0",
     "eslint-plugin-standard": "^4.0.0",
-    "istanbul": "^0.4.5",
     "jasmine": "^3.4.0",
     "jasmine-spec-reporter": "^4.2.1",
+    "nyc": "^14.1.1",
     "osenv": "^0.1.3",
     "promise-matchers": "^0.9.6",
     "rewire": "^4.0.1"
   },
-  "contributors": []
+  "contributors": [],
+  "nyc": {
+    "all": true,
+    "exclude": [
+      "spec/"
+    ],
+    "reporter": [
+      "lcov",
+      "text"
+    ]
+  }
 }


### PR DESCRIPTION
### Motivation and Context

`instanbul` is no longer maintained and we use `nyc` across all other repos.

Closes #72

### Description

Drop `instanbul`
Added `nyc` & configs

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
