### PR TITLE
chore: improve npm ignore list

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,4 @@
+.*
+appveyor.yml
 spec
 coverage


### PR DESCRIPTION
### Motivation and Context

Decrease production package size

### Description

Drop From Package
* all dot file and folders with .* (.github, .travis.yml, .eslintrc.yml, etc...)
  * .github/
  * .travis.yml
  * .eslintrc.yml
  * .eslintignore
  * .ratignore
* appveyor.yml

**BEFORE**
npm notice package size:  41.5 kB
npm notice unpacked size: 179.4 kB
npm notice total files:   34

**AFTER**
npm notice package size:  39.1 kB
npm notice unpacked size: 173.8 kB
npm notice total files:   24

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
