### PR TITLE
refactor: eslint setup

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
-spec/fixtures/*
+coverage/
+spec/fixtures/

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,2 +1,7 @@
 root: true
 extends: '@cordova/eslint-config/node'
+
+rules:
+  no-unused-vars:
+    - error
+    - args: after-used

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,10 +1,2 @@
 root: true
-extends: semistandard
-rules:
-  indent:
-    - error
-    - 4
-  camelcase: off
-  no-unused-vars:
-    - error
-    - args: after-used
+extends: '@cordova/eslint-config/node'

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -5,3 +5,5 @@ rules:
   no-unused-vars:
     - error
     - args: after-used
+      vars: all
+      ignoreRestSiblings: true

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "node": ">=10.0.0"
   },
   "scripts": {
-    "test": "npm run eslint && npm run cover",
+    "test": "npm run lint && npm run cover",
     "test:unit": "jasmine \"spec/**/*.spec.js\"",
-    "eslint": "eslint src spec",
+    "lint": "eslint .",
     "cover": "nyc npm run test:unit"
   },
   "dependencies": {
@@ -37,13 +37,7 @@
     "underscore": "^1.9.1"
   },
   "devDependencies": {
-    "eslint": "^5.0.0",
-    "eslint-config-semistandard": "^14.0.0",
-    "eslint-config-standard": "^13.0.1",
-    "eslint-plugin-import": "^2.14.0",
-    "eslint-plugin-node": "^8.0.0",
-    "eslint-plugin-promise": "^4.0.0",
-    "eslint-plugin-standard": "^4.0.0",
+    "@cordova/eslint-config": "^2.0.0",
     "jasmine": "^3.5.0",
     "jasmine-spec-reporter": "^4.2.1",
     "nyc": "^14.1.1",

--- a/spec/.eslintrc.yml
+++ b/spec/.eslintrc.yml
@@ -1,6 +1,5 @@
-env:
-    jasmine: true
+root: true
+extends: '@cordova/eslint-config/node-tests'
 
-# Not covered by jasmine env as of writing
 globals:
-    expectAsync: false
+  expectAsync: false

--- a/spec/ConfigChanges/ConfigChanges.spec.js
+++ b/spec/ConfigChanges/ConfigChanges.spec.js
@@ -476,7 +476,7 @@ describe('config-changes module', function () {
 
                 expect(platformJson.root.prepare_queue.installed.length).toEqual(0);
                 expect(platformJson.root.installed_plugins['com.adobe.vars']).toBeDefined();
-                expect(platformJson.root.installed_plugins['com.adobe.vars']['API_KEY']).toEqual('hi');
+                expect(platformJson.root.installed_plugins['com.adobe.vars'].API_KEY).toEqual('hi');
             });
         });
 
@@ -517,7 +517,7 @@ describe('config-changes module', function () {
                 var munge_params = spy.calls.argsFor(0);
                 expect(munge_params[0]).toEqual(jasmine.any(PluginInfo));
                 expect(munge_params[0].dir).toEqual(path.join(plugins_dir, 'com.adobe.vars'));
-                expect(munge_params[1]['API_KEY']).toEqual('canucks');
+                expect(munge_params[1].API_KEY).toEqual('canucks');
             });
             it('Test 029 : should not call pruneXML for a config munge that another plugin depends on', function () {
                 fs.copySync(android_two_no_perms_project, temp);

--- a/spec/PluginInfo/PluginInfo.spec.js
+++ b/spec/PluginInfo/PluginInfo.spec.js
@@ -69,7 +69,7 @@ describe('PluginInfo', function () {
         expect(Object.keys(podSpec.libraries).length).toBe(4);
         expect(podSpec.declarations['use-frameworks']).toBe('true');
         expect(podSpec.sources['https://github.com/CocoaPods/Specs.git'].source).toBe('https://github.com/CocoaPods/Specs.git');
-        expect(podSpec.libraries['AFNetworking'].spec).toBe('~> 3.2');
-        expect(podSpec.libraries['Eureka']['swift-version']).toBe('4.1');
+        expect(podSpec.libraries.AFNetworking.spec).toBe('~> 3.2');
+        expect(podSpec.libraries.Eureka['swift-version']).toBe('4.1');
     });
 });

--- a/src/ConfigChanges/ConfigChanges.js
+++ b/src/ConfigChanges/ConfigChanges.js
@@ -392,7 +392,8 @@ function is_conflicting (editchanges, config_munge, self, force) {
         }
     });
 
-    return { conflictFound: conflictFound,
+    return {
+        conflictFound: conflictFound,
         conflictingPlugin: conflictingPlugin,
         conflictingMunge: conflictingMunge,
         configxmlMunge: configxmlMunge,

--- a/src/ConfigParser/ConfigParser.js
+++ b/src/ConfigParser/ConfigParser.js
@@ -99,7 +99,7 @@ ConfigParser.prototype = {
         return this.getAttribute('id');
     },
     setPackageName: function (id) {
-        this.doc.getroot().attrib['id'] = id;
+        this.doc.getroot().attrib.id = id;
     },
     android_packageName: function () {
         return this.getAttribute('android-packageName');
@@ -118,14 +118,14 @@ ConfigParser.prototype = {
         el.text = name;
     },
     shortName: function () {
-        return this.doc.find('name').attrib['short'] || this.name();
+        return this.doc.find('name').attrib.short || this.name();
     },
     setShortName: function (shortname) {
         var el = findOrCreate(this.doc, 'name');
         if (!el.text) {
             el.text = shortname;
         }
-        el.attrib['short'] = shortname;
+        el.attrib.short = shortname;
     },
     description: function () {
         return getNodeTextSafe(this.doc.find('description'));
@@ -147,7 +147,7 @@ ConfigParser.prototype = {
         return this.getAttribute('ios-CFBundleVersion');
     },
     setVersion: function (value) {
-        this.doc.getroot().attrib['version'] = value;
+        this.doc.getroot().attrib.version = value;
     },
     author: function () {
         return getNodeTextSafe(this.doc.find('author'));
@@ -229,7 +229,7 @@ ConfigParser.prototype = {
             var res = {};
             res.src = elt.attrib.src;
             res.target = elt.attrib.target || undefined;
-            res.density = elt.attrib['density'] || elt.attrib[that.cdvNamespacePrefix + ':density'] || elt.attrib['gap:density'];
+            res.density = elt.attrib.density || elt.attrib[that.cdvNamespacePrefix + ':density'] || elt.attrib['gap:density'];
             res.platform = elt.platform || null; // null means icon represents default icon (shared between platforms)
             res.width = +elt.attrib.width || undefined;
             res.height = +elt.attrib.height || undefined;
@@ -564,9 +564,9 @@ ConfigParser.prototype = {
         return edit_configs.map(function (tag) {
             var editConfig =
                 {
-                    file: tag.attrib['file'],
-                    target: tag.attrib['target'],
-                    mode: tag.attrib['mode'],
+                    file: tag.attrib.file,
+                    target: tag.attrib.target,
+                    mode: tag.attrib.mode,
                     id: 'config.xml',
                     xmls: tag.getchildren()
                 };
@@ -582,12 +582,12 @@ ConfigParser.prototype = {
         return config_files.map(function (tag) {
             var configFile =
                 {
-                    target: tag.attrib['target'],
-                    parent: tag.attrib['parent'],
-                    after: tag.attrib['after'],
+                    target: tag.attrib.target,
+                    parent: tag.attrib.parent,
+                    after: tag.attrib.after,
                     xmls: tag.getchildren(),
                     // To support demuxing via versions
-                    versions: tag.attrib['versions'],
+                    versions: tag.attrib.versions,
                     deviceTarget: tag.attrib['device-target']
                 };
             return configFile;

--- a/src/ConfigParser/ConfigParser.js
+++ b/src/ConfigParser/ConfigParser.js
@@ -562,14 +562,13 @@ ConfigParser.prototype = {
         var edit_configs = this.doc.findall('edit-config').concat(platform_edit_configs);
 
         return edit_configs.map(function (tag) {
-            var editConfig =
-                {
-                    file: tag.attrib.file,
-                    target: tag.attrib.target,
-                    mode: tag.attrib.mode,
-                    id: 'config.xml',
-                    xmls: tag.getchildren()
-                };
+            var editConfig = {
+                file: tag.attrib.file,
+                target: tag.attrib.target,
+                mode: tag.attrib.mode,
+                id: 'config.xml',
+                xmls: tag.getchildren()
+            };
             return editConfig;
         });
     },
@@ -580,16 +579,15 @@ ConfigParser.prototype = {
         var config_files = this.doc.findall('config-file').concat(platform_config_files);
 
         return config_files.map(function (tag) {
-            var configFile =
-                {
-                    target: tag.attrib.target,
-                    parent: tag.attrib.parent,
-                    after: tag.attrib.after,
-                    xmls: tag.getchildren(),
-                    // To support demuxing via versions
-                    versions: tag.attrib.versions,
-                    deviceTarget: tag.attrib['device-target']
-                };
+            var configFile = {
+                target: tag.attrib.target,
+                parent: tag.attrib.parent,
+                after: tag.attrib.after,
+                xmls: tag.getchildren(),
+                // To support demuxing via versions
+                versions: tag.attrib.versions,
+                deviceTarget: tag.attrib['device-target']
+            };
             return configFile;
         });
     },

--- a/src/PluginInfo/PluginInfo.js
+++ b/src/PluginInfo/PluginInfo.js
@@ -101,14 +101,13 @@ function PluginInfo (dirname) {
     }
 
     function _parseDependency (tag) {
-        var dep =
-            {
-                id: tag.attrib.id,
-                version: tag.attrib.version || '',
-                url: tag.attrib.url || '',
-                subdir: tag.attrib.subdir || '',
-                commit: tag.attrib.commit
-            };
+        var dep = {
+            id: tag.attrib.id,
+            version: tag.attrib.version || '',
+            url: tag.attrib.url || '',
+            subdir: tag.attrib.subdir || '',
+            commit: tag.attrib.commit
+        };
 
         dep.git_ref = dep.commit;
 

--- a/src/PluginInfo/PluginInfo.js
+++ b/src/PluginInfo/PluginInfo.js
@@ -102,7 +102,8 @@ function PluginInfo (dirname) {
 
     function _parseDependency (tag) {
         var dep =
-            { id: tag.attrib.id,
+            {
+                id: tag.attrib.id,
                 version: tag.attrib.version || '',
                 url: tag.attrib.url || '',
                 subdir: tag.attrib.subdir || '',
@@ -129,15 +130,15 @@ function PluginInfo (dirname) {
     }
 
     function _parseConfigFile (tag) {
-        var configFile =
-            { target: tag.attrib['target'],
-                parent: tag.attrib['parent'],
-                after: tag.attrib['after'],
-                xmls: tag.getchildren(),
-                // To support demuxing via versions
-                versions: tag.attrib['versions'],
-                deviceTarget: tag.attrib['device-target']
-            };
+        var configFile = {
+            target: tag.attrib.target,
+            parent: tag.attrib.parent,
+            after: tag.attrib.after,
+            xmls: tag.getchildren(),
+            // To support demuxing via versions
+            versions: tag.attrib.versions,
+            deviceTarget: tag.attrib['device-target']
+        };
         return configFile;
     }
 
@@ -148,12 +149,12 @@ function PluginInfo (dirname) {
     }
 
     function _parseEditConfigs (tag) {
-        var editConfig =
-            { file: tag.attrib['file'],
-                target: tag.attrib['target'],
-                mode: tag.attrib['mode'],
-                xmls: tag.getchildren()
-            };
+        var editConfig = {
+            file: tag.attrib.file,
+            target: tag.attrib.target,
+            mode: tag.attrib.mode,
+            xmls: tag.getchildren()
+        };
         return editConfig;
     }
 
@@ -203,7 +204,7 @@ function PluginInfo (dirname) {
                 itemType: 'header-file',
                 src: tag.attrib.src,
                 targetDir: tag.attrib['target-dir'],
-                type: tag.attrib['type']
+                type: tag.attrib.type
             };
         });
         return headerFiles;


### PR DESCRIPTION
### Motivation and Context

Code syntax cleanup

Closes #73

### Description

* replace dependencies with @cordova/eslint-config
* update eslint config
* eslint corrections

### Testing

- `npm t`
- `npm run eslint`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
