### PR TITLE
ci(travis): run codecov using npx in after_success

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,10 @@ node_js:
 
 install:
   - npm install
-  - npm install -g codecov
 
 script:
   - npm test
   - npm run cover
 
-after_script:
-  - codecov
+after_success:
+  - npx codecov


### PR DESCRIPTION
- `codecov` installation and execution in one line thanks to `npx`
- `codecov` only is installed and run if the tests succeed