### PR TITLE
test: always run code coverage during `npm test`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ install:
 
 script:
   - npm test
-  - npm run cover
 
 after_script:
   - codecov

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "node": ">=10.0.0"
   },
   "scripts": {
-    "test": "npm run eslint && npm run test:unit",
+    "test": "npm run eslint && npm run cover",
     "test:unit": "jasmine \"spec/**/*.spec.js\"",
     "eslint": "eslint src spec",
     "cover": "nyc npm run test:unit"


### PR DESCRIPTION
- This is in line with our other repos.
- We don't need to run the tests twice on Travis CI