### PR TITLE
style: drop jasmine env workaround

### DIFF
--- a/spec/.eslintrc.yml
+++ b/spec/.eslintrc.yml
@@ -1,5 +1,2 @@
 root: true
 extends: '@cordova/eslint-config/node-tests'
-
-globals:
-  expectAsync: false


### PR DESCRIPTION
ESLint 6.7.0 has just been released and it contains the latest globals
for the jasmine environment. Thus we do not have to add them ourselves.