### PR TITLE
chore!: remove main export mungeUtil

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,6 @@ PlatformJson
 ConfigChanges
 ConfigKeeper
 ConfigFile
-mungeUtil
 ```
 
 ## Setup

--- a/cordova-common.js
+++ b/cordova-common.js
@@ -37,7 +37,6 @@ module.exports = {
     get ConfigChanges () { return require('./src/ConfigChanges/ConfigChanges'); },
     get ConfigKeeper () { return require('./src/ConfigChanges/ConfigKeeper'); },
     get ConfigFile () { return require('./src/ConfigChanges/ConfigFile'); },
-    get mungeUtil () { return require('./src/ConfigChanges/munge-util'); },
 
     get xmlHelpers () { return require('./src/util/xml-helpers'); }
 };


### PR DESCRIPTION
Removes `mungeUtil` from the list of modules that are exported by `cordova-common`. It was documented as _internal_ and we did not use it in any of our repos.