### PR TITLE
fix(ConfigFile): Normalize globbed file paths

### DIFF
--- a/spec/ConfigChanges/ConfigChanges.spec.js
+++ b/spec/ConfigChanges/ConfigChanges.spec.js
@@ -472,7 +472,7 @@ describe('config-changes module', function () {
 
                 var munger = new configChanges.PlatformMunger('ios', temp, platformJson, pluginInfoProvider);
                 munger.process(plugins_dir);
-                expect(spy).toHaveBeenCalledWith(path.join(temp, 'SampleApp', 'SampleApp-Info.plist').replace(/\\/g, '/'), 'utf8');
+                expect(spy).toHaveBeenCalledWith(path.join(temp, 'SampleApp', 'SampleApp-Info.plist'), 'utf8');
             });
             it('Test 026 : should move successfully installed plugins from queue to installed plugins section, and include/retain vars if applicable', function () {
                 fs.copySync(android_two_project, temp);

--- a/src/ConfigChanges/ConfigFile.js
+++ b/src/ConfigChanges/ConfigFile.js
@@ -167,7 +167,9 @@ function resolveConfigFilePath (project_dir, platform, file) {
 
     if (file.includes('*')) {
         // handle wildcards in targets using glob.
-        matches = modules.glob.sync(path.join(project_dir, '**', file));
+        matches = modules.glob.sync(path.join(project_dir, '**', file))
+            .map(p => path.normalize(p));
+
         if (matches.length) filepath = matches[0];
 
         // [CB-5989] multiple Info.plist files may exist. default to $PROJECT_NAME-Info.plist


### PR DESCRIPTION
Glob always returns paths with forward slashes. This change ensures that a config file path obtained from a glob pattern will use the platform-specific path segment separator.

In preparation of merging #124.