### PR TITLE
fix(ConfigParser): ImageResources constructor

### DIFF
--- a/spec/ConfigParser/ConfigParser.spec.js
+++ b/spec/ConfigParser/ConfigParser.spec.js
@@ -328,6 +328,12 @@ describe('config.xml parser', function () {
                 expect(cfg.getStaticResources('android', 'icon').getByDensity('mdpi')).toBeDefined();
                 expect(cfg.getStaticResources('android', 'icon').getByDensity('mdpi').src).toBe('logo-android.png');
             });
+
+            it('Test 042 : should return an array that has a working map method', function () {
+                expect(() =>
+                    cfg.getStaticResources(null, 'icon').map(x => x)
+                ).not.toThrow();
+            });
         });
 
         describe('file resources', function () {

--- a/src/ConfigParser/ConfigParser.js
+++ b/src/ConfigParser/ConfigParser.js
@@ -201,7 +201,7 @@ class ConfigParser {
         const commonResources = this.doc.findall(resourceName)
             .map(elt => new ImageResource(normalizedAttrs(elt)));
 
-        return new ImageResources(...platformResources, ...commonResources);
+        return ImageResources.create(...platformResources, ...commonResources);
     }
 
     /**
@@ -580,13 +580,22 @@ class FileResource extends BaseResource {
 }
 
 class ImageResources extends Array {
-    constructor (...args) {
-        super(...args);
-
-        // The spread is necessary to avoid infinite recursion
-        this.defaultResource = [...this].filter(res =>
+    /**
+     * Creates an ImageResources instance with defaultResource property.
+     *
+     * It is easy to break native Array methods like `map` when carelessly
+     * overriding the array constructor, so it's safer to use this factory
+     * function for our needs instead.
+     *
+     * @param {...ImageResource} args - The entries of this array
+     * @return {ImageResources} An ImageResources instance with args as entries
+     */
+    static create (...args) {
+        const defaultResource = args.filter(res =>
             !res.width && !res.height && !res.density
         ).pop();
+
+        return Object.assign(new ImageResources(...args), { defaultResource });
     }
 
     /**


### PR DESCRIPTION


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The previous `ImageResources` constructor did not cover the case where a single integer argument is given to construct an empty array of the given length. This broke the `map` method since it uses that constructor variant.





### Description
<!-- Describe your changes in detail -->

This PR fixes that situation by using a static factory method instead of overriding the native Array constructor.

### Testing
<!-- Please describe in detail how you tested your changes. -->
New regression test passes
