### PR TITLE
fix: resolve correct path to app info plist when multiple plist files are present (#144)

### DIFF
--- a/spec/ConfigChanges/ConfigFile.spec.js
+++ b/spec/ConfigChanges/ConfigFile.spec.js
@@ -104,7 +104,7 @@ describe('ConfigFile tests', function () {
 
             it('should return *-Info.plist file', function () {
                 const projName = 'XXX';
-                const expectedPlistPath = `${projName}-Info.plist`;
+                const expectedPlistPath = `${projName}${path.sep}${projName}-Info.plist`;
 
                 ConfigFile.__set__('getIOSProjectname', () => projName);
                 spyOn(require('glob'), 'sync').and.returnValue([

--- a/src/ConfigChanges/ConfigFile.js
+++ b/src/ConfigChanges/ConfigFile.js
@@ -174,8 +174,9 @@ function resolveConfigFilePath (project_dir, platform, file) {
 
         // [CB-5989] multiple Info.plist files may exist. default to $PROJECT_NAME-Info.plist
         if (matches.length > 1 && file.includes('-Info.plist')) {
-            const plistName = `${getIOSProjectname(project_dir)}-Info.plist`;
-            const plistPath = path.join(project_dir, plistName);
+            const projName = getIOSProjectname(project_dir);
+            const plistName = `${projName}-Info.plist`;
+            const plistPath = path.join(project_dir, projName, plistName);
             if (matches.includes(plistPath)) return plistPath;
         }
         return filepath;


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

When multiple plist files exists in a cordova-ios project (e.g. due to a plugin containing `<podspec>`), ConfigFile was updated under CB-5989 to select the app plist as the target for changes destined for *-Info.plist.
However, the change made under CB-5989 incorrectly constructed the path to the app plist by omitting the project name subdirectory from the path, causing the fix to fail to work.

This bug is outlined in #144. 

### Description
<!-- Describe your changes in detail -->
This commit fixes this by correcting the constructed path to the app plist.


### Testing
<!-- Please describe in detail how you tested your changes. -->
I've created a repo containing a test Cordova project which reproduces the various scenarios to illustrate the issue:
https://github.com/dpa99c/cordova-common-issue-144

Details of these scenarios can be found in [this comment](https://github.com/apache/cordova-common/issues/144#issuecomment-643215608).


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change **N/A**
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary **N/A**
