### PR TITLE
ci: add node 14 to workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [10.x, 12.x, 14.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:


### PR DESCRIPTION
### Motivation and Context & Description

- Add Node 14 to CI Workflow
- Task Tracker: https://github.com/apache/cordova/issues/223

### Testing

- See CI
