### PR TITLE
fix: doc.find is not a function

### DIFF
--- a/src/util/xml-helpers.js
+++ b/src/util/xml-helpers.js
@@ -128,7 +128,13 @@ module.exports = {
     },
 
     resolveParent: function (doc, selector) {
-        if (!selector.startsWith('/')) return doc.find(selector);
+        if (!selector.startsWith('/')) {
+            try {
+                return doc.find(selector);
+            } catch(error) {
+                return doc[selector];
+            }
+        }
 
         // elementtree does not implement absolute selectors so we build an
         // extended tree where we can use an equivalent relative selector


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

cordova-ios

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Closes #156

### Description
<!-- Describe your changes in detail -->

added try/catch block and return a property, because doc in this case an object and doc.find throw an error


### Testing
<!-- Please describe in detail how you tested your changes. -->

fixed on global package and reinstall cordova-ios and did cordova prepare -> result no doc.find erros.


### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
