### PR TITLE
fix(ConfigChanges): do not pass PlistValue to xml_helpers.resolveParent

### DIFF
--- a/src/ConfigChanges/ConfigChanges.js
+++ b/src/ConfigChanges/ConfigChanges.js
@@ -311,13 +311,18 @@ class PlatformMunger {
 
                 // Check if the edit target will resolve to an existing target
                 if (!target || target.length === 0) {
-                    const file_xml = this.config_keeper.get(this.project_dir, this.platform, editchange.file).data;
-                    const resolveEditTarget = xml_helpers.resolveParent(file_xml, editchange.target);
-                    let resolveTarget;
+                    const targetFile = this.config_keeper.get(this.project_dir, this.platform, editchange.file);
 
+                    // For non-XML files (e.g. plist), the selector in editchange.target uniquely identifies its target.
+                    // Thus we already know that we have no conflict if we are not dealing with an XML file here.
+                    if (targetFile.type !== 'xml') return;
+
+                    // For XML files, the selector does NOT uniquely identify its target. So we resolve editchange.target
+                    // and any existing selectors to their matched elements and compare those for equality.
+                    const resolveEditTarget = xml_helpers.resolveParent(targetFile.data, editchange.target);
                     if (resolveEditTarget) {
                         for (const parent in parents) {
-                            resolveTarget = xml_helpers.resolveParent(file_xml, parent);
+                            const resolveTarget = xml_helpers.resolveParent(targetFile.data, parent);
                             if (resolveEditTarget === resolveTarget) {
                                 conflictingParent = parent;
                                 target = parents[parent];


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Apparently, when providing two `<edit-config>`s targeting the same `*.plist` file, then our conflict-checking code tried to apply XML-only logic to a Plist file representation. This resulted in the error described in #156.

Fixes #156, closes #157

### Description
<!-- Describe your changes in detail -->
I added an explicit check for the type of file an `<edit-config>` applies to. Now we only do the XML-specific stuff when dealing with XML files.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Manual testing against repro provided in #156

It would be great if we had a regression test for this. So if someone has time to add one, that would be great. If not we might have to make do without one.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
