### PR TITLE
test: fix invalid config for jasmine-spec-reporter

### DIFF
--- a/spec/helper.js
+++ b/spec/helper.js
@@ -26,6 +26,6 @@ jasmine.getEnv().addReporter(new SpecReporter({
     },
     summary: {
         displayDuration: true,
-        displayStacktrace: true
+        displayStacktrace: 'raw'
     }
 }));


### PR DESCRIPTION
Fixes the following warning:

    WARN: jasmine-spec-reporter 'displayStacktrace' option supports value ('none', 'raw', 'pretty'), default to 'none'

And of course shows stack traces for errors during test runs again.