### PR TITLE
feat(PluginInfo): add podspec plugins support (#177)

### DIFF
--- a/spec/PluginInfo/PluginInfo.spec.js
+++ b/spec/PluginInfo/PluginInfo.spec.js
@@ -67,9 +67,12 @@ describe('PluginInfo', function () {
         expect(Object.keys(podSpec.declarations).length).toBe(2);
         expect(Object.keys(podSpec.sources).length).toBe(1);
         expect(Object.keys(podSpec.libraries).length).toBe(4);
+        expect(Object.keys(podSpec.plugins).length).toBe(2);
         expect(podSpec.declarations['use-frameworks']).toBe('true');
         expect(podSpec.sources['https://github.com/CocoaPods/Specs.git'].source).toBe('https://github.com/CocoaPods/Specs.git');
         expect(podSpec.libraries.AFNetworking.spec).toBe('~> 3.2');
         expect(podSpec.libraries.Eureka['swift-version']).toBe('4.1');
+        expect(podSpec.plugins['my-other-plugin'].name).toBe('my-other-plugin');
+        expect(podSpec.plugins['cocoapods-art'].options).toBe(":sources => [ 'my.source.url' ]");
     });
 });

--- a/spec/fixtures/plugins/org.test.plugins.withcocoapods/plugin.xml
+++ b/spec/fixtures/plugins/org.test.plugins.withcocoapods/plugin.xml
@@ -44,6 +44,10 @@
           <pod name="Eureka" swift-version="4.1" />
           <pod name="AcknowList" />
         </pods>
+        <plugins>
+            <plugin name="my-other-plugin" />
+            <plugin name="cocoapods-art" options=":sources =&gt; [ &apos;my.source.url&apos; ]" />
+        </plugins>
       </podspec>
     </platform>
 </plugin>

--- a/src/PluginInfo/PluginInfo.js
+++ b/src/PluginInfo/PluginInfo.js
@@ -257,6 +257,10 @@ class PluginInfo {
      *          <pod name="Foobar4" swift-version="4.1" />
      *          <pod name="Foobar5" swift-version="3.0" />
      *      </pods>
+     *      <plugins>
+     *          <plugin name="my-other-plugin" />
+     *          <plugin name="cocoapods-art" options=":sources =&gt; [ &apos;my.repo.name&apos; ]" />
+     *      </plugins>
      *  </podspec>
      *
      * @param {string} platform
@@ -265,6 +269,7 @@ class PluginInfo {
         return this._getTagsInPlatform('podspec', platform).map(tag => {
             const config = tag.find('config');
             const pods = tag.find('pods');
+            const pluginsTag = tag.find('plugins');
 
             const sources = config && config.findall('source')
                 .map(el => ({ source: el.attrib.url }))
@@ -276,7 +281,11 @@ class PluginInfo {
                 .map(t => t.attrib)
                 .reduce((acc, val) => Object.assign(acc, { [val.name]: val }), {});
 
-            return { declarations, sources, libraries };
+            const plugins = pluginsTag && pluginsTag.findall('plugin')
+                .map(t => t.attrib)
+                .reduce((acc, val) => Object.assign(acc, { [val.name]: val }), {});
+
+            return { declarations, sources, libraries, plugins };
         });
     }
 


### PR DESCRIPTION
### Platforms affected
iOS platform


### Motivation and Context
This PR adds support for a new "plugins" and "plugin" elements in the "podspec" section of the plugin.xml to support the Cocoapods Plugins syntax standards:

Closes #177 

### Description
See description in https://github.com/apache/cordova-ios/issues/1256


### Testing
Automated tests have been updated to reflect the change



### Checklist

- [X] I've run the tests to see all new and existing tests pass
- [X] I added automated test coverage as appropriate for this change
- [X] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [X] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [X] I've updated the documentation if necessary
