### PR TITLE
Added link attribute support to the framework tag.

### DIFF
--- a/spec/PluginInfo/PluginInfo.spec.js
+++ b/spec/PluginInfo/PluginInfo.spec.js
@@ -72,4 +72,46 @@ describe('PluginInfo', function () {
         expect(podSpec.libraries.AFNetworking.spec).toBe('~> 3.2');
         expect(podSpec.libraries.Eureka['swift-version']).toBe('4.1');
     });
+
+    describe('Test 006: framework embed and link interactions', function () {
+        const p = new PluginInfo(path.join(pluginsDir, 'org.test.framework_embed_link'));
+        const result = p.getFrameworks(null, {});
+
+        it('embed true, link true', function () {
+            expect(result[0].embed).toBe(true);
+            expect(result[0].link).toBe(true);
+        });
+
+        it('embed true, link false', function () {
+            expect(result[1].embed).toBe(true);
+            expect(result[1].link).toBe(false);
+        });
+
+        it('embed false, link true', function () {
+            expect(result[2].embed).toBe(false);
+            expect(result[2].link).toBe(true);
+        });
+
+        it('embed false, link false', function () {
+            expect(result[3].embed).toBe(false);
+            expect(result[3].link).toBe(false);
+        });
+
+        // Undefined means the attribute didn't exist in the framework tag XML.
+
+        it('embed undefined, link undefined', function () {
+            expect(result[4].embed).toBe(false);
+            expect(result[4].link).toBe(null);
+        });
+
+        it('embed true, link undefined', function () {
+            expect(result[5].embed).toBe(true);
+            expect(result[5].link).toBe(null);
+        });
+
+        it('embed false, link undefined', function () {
+            expect(result[6].embed).toBe(false);
+            expect(result[5].link).toBe(null);
+        });
+    });
 });

--- a/spec/PluginInfo/PluginInfo.spec.js
+++ b/spec/PluginInfo/PluginInfo.spec.js
@@ -73,43 +73,43 @@ describe('PluginInfo', function () {
         expect(podSpec.libraries.Eureka['swift-version']).toBe('4.1');
     });
 
-    describe('Test 006: framework embed and link interactions', function () {
+    describe('framework embed and link interactions', function () {
         const p = new PluginInfo(path.join(pluginsDir, 'org.test.framework_embed_link'));
         const result = p.getFrameworks(null, {});
 
-        it('embed true, link true', function () {
+        it('Test 006: embed true, link true', function () {
             expect(result[0].embed).toBe(true);
             expect(result[0].link).toBe(true);
         });
 
-        it('embed true, link false', function () {
+        it('Test 007: embed true, link false', function () {
             expect(result[1].embed).toBe(true);
             expect(result[1].link).toBe(false);
         });
 
-        it('embed false, link true', function () {
+        it('Test 008: embed false, link true', function () {
             expect(result[2].embed).toBe(false);
             expect(result[2].link).toBe(true);
         });
 
-        it('embed false, link false', function () {
+        it('Test 009: embed false, link false', function () {
             expect(result[3].embed).toBe(false);
             expect(result[3].link).toBe(false);
         });
 
         // Undefined means the attribute didn't exist in the framework tag XML.
 
-        it('embed undefined, link undefined', function () {
+        it('Test 010: embed undefined, link undefined', function () {
             expect(result[4].embed).toBe(false);
             expect(result[4].link).toBe(null);
         });
 
-        it('embed true, link undefined', function () {
+        it('Test 011: embed true, link undefined', function () {
             expect(result[5].embed).toBe(true);
             expect(result[5].link).toBe(null);
         });
 
-        it('embed false, link undefined', function () {
+        it('Test 012: embed false, link undefined', function () {
             expect(result[6].embed).toBe(false);
             expect(result[5].link).toBe(null);
         });

--- a/spec/fixtures/plugins/org.test.framework_embed_link/plugin.xml
+++ b/spec/fixtures/plugins/org.test.framework_embed_link/plugin.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<plugin xmlns="http://cordova.apache.org/ns/plugins/1.0"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    id="org.test.editconfigtest_two"
+    version="3.0.0">
+
+    <name>Test embed and link interactions</name>
+
+    <framework src="notexistingthing.xcframework" embed="true" link="true" />
+    <framework src="notexistingthing.xcframework" embed="true" link="false" />
+    <framework src="notexistingthing.xcframework" embed="false" link="true" />
+    <framework src="notexistingthing.xcframework" embed="false" link="false" />
+    <framework src="notexistingthing.xcframework" />
+    <framework src="notexistingthing.xcframework" embed="true" />
+    <framework src="notexistingthing.xcframework" embed="false" />
+</plugin>

--- a/src/PluginInfo/PluginInfo.js
+++ b/src/PluginInfo/PluginInfo.js
@@ -352,6 +352,10 @@ class PluginInfo {
             parent: attrib.parent,
             custom: isStrTrue(attrib.custom),
             embed: isStrTrue(attrib.embed),
+            // link can be set to null for backwards compatibility. Without null this would be a breaking change.
+            // If it's always true or false platforms will not know when to fallback to pre-link attribute behaviour.
+            // By setting link to null when it's not explicitly set we allow platforms to support backwards compatibility.
+            link: attrib.link === 'true' || attrib.link === 'false' ? isStrTrue(attrib.link) : null,
             src: expandVars(attrib.src),
             spec: attrib.spec,
             weak: isStrTrue(attrib.weak),


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS

Technically this change will be available to all platforms however; the platforms themselves need to be updated to use this change. If they are not updated, they will not behave any differently.
iOS is the only platform that actually needs this change.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Currently, the framework tag does not support both linking and embedding a framework. Comments in the code suggest this was a limitation in Apple's code.

This limitation no longer exists. The current default behaviour of XCode (version 14) when dragging and dropping an XCFramework into General -> "Frameworks, Libraries, and Embedded Content" is to both embed and link the XCFramework.
I have only tested this with XCFramework but I assume other kinds of frameworks behave the same.

This change supports reading a new attribute, "link" from the framework tags. The cordova-ios platform will then be able to use the new link attribute to support both linking and embedding a XCFramework.

cordova-ios pr: https://github.com/apache/cordova-ios/pull/1266
cordova-docs pr: https://github.com/apache/cordova-docs/pull/1267

<!-- If it fixes an open issue, please link to the issue here. -->



### Description
<!-- Describe your changes in detail -->
Updated PluginInfo to read the property "link" from framework attributes.

If link is explicitly set to expected values "true" or "false", then convert the value to a boolean.
If link is not explicitly set, then set link to null.

Link is set to null when it is not explicitly set to support backwards compatibility. If link is null, platforms should fallback to the behaviour they were doing before these changes.

### Testing
<!-- Please describe in detail how you tested your changes. -->

I've added unit testing for embed and link interactions and ran npm test.

Tested various combinations of framework tag's embed and link attributes by installing a plugin using these attributes. I would observe how the XCFramework is added to the the XCode project with the following focuses:
-Is the XCFramework embedded (or not embedded) in Build Phrases?
-Is the XCFramework linked (or not linked) in Build Phrases?
-Is the XCFramework set to "Embed and Sign" in General?

I have ran my company's app using these changes.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
