### PR TITLE
feat(PluginInfo): pass through XML attributes

### DIFF
--- a/spec/PluginInfo/PluginInfo.spec.js
+++ b/spec/PluginInfo/PluginInfo.spec.js
@@ -20,6 +20,7 @@
 const PluginInfo = require('../../src/PluginInfo/PluginInfo');
 const path = require('path');
 const pluginsDir = path.join(__dirname, '../fixtures/plugins');
+const pluginPassthrough = new PluginInfo(path.join(pluginsDir, 'org.test.xmlpassthrough'));
 
 describe('PluginInfo', function () {
     it('Test 001 : should read a plugin.xml file', function () {
@@ -47,29 +48,145 @@ describe('PluginInfo', function () {
         expect(() => new PluginInfo('/non/existent/dir')).toThrow();
     });
 
-    it('Test 003: replace framework src', function () {
-        const p = new PluginInfo(path.join(pluginsDir, 'org.test.src'));
-        const result = p.getFrameworks('android', { cli_variables: { FCM_VERSION: '9.0.0' } });
-        expect(result[2].src).toBe('com.google.firebase:firebase-messaging:9.0.0');
+    describe('Framework', () => {
+        it('Test 003: replace framework src', function () {
+            const p = new PluginInfo(path.join(pluginsDir, 'org.test.src'));
+            const result = p.getFrameworks('android', { cli_variables: { FCM_VERSION: '9.0.0' } });
+            expect(result[2].src).toBe('com.google.firebase:firebase-messaging:9.0.0');
+        });
+
+        it('Test 004: framework src uses default variable', function () {
+            const p = new PluginInfo(path.join(pluginsDir, 'org.test.src'));
+            const result = p.getFrameworks('android', {});
+            expect(result[2].src).toBe('com.google.firebase:firebase-messaging:11.0.1');
+        });
+
+        it('Test 006: framework supports xml passthrough', function () {
+            const frameworks = pluginPassthrough.getFrameworks('android', {});
+            expect(frameworks.length).toBe(1);
+            expect(frameworks[0].anattrib).toBe('value');
+        });
     });
 
-    it('Test 004: framework src uses default variable', function () {
-        const p = new PluginInfo(path.join(pluginsDir, 'org.test.src'));
-        const result = p.getFrameworks('android', {});
-        expect(result[2].src).toBe('com.google.firebase:firebase-messaging:11.0.1');
+    describe('Podspec', () => {
+        it('Test 005: read podspec', function () {
+            const p = new PluginInfo(path.join(pluginsDir, 'org.test.plugins.withcocoapods'));
+            const result = p.getPodSpecs('ios');
+            expect(result.length).toBe(1);
+            const podSpec = result[0];
+            expect(Object.keys(podSpec.declarations).length).toBe(2);
+            expect(Object.keys(podSpec.sources).length).toBe(1);
+            expect(Object.keys(podSpec.libraries).length).toBe(4);
+            expect(podSpec.declarations['use-frameworks']).toBe('true');
+            expect(podSpec.sources['https://github.com/CocoaPods/Specs.git'].source).toBe('https://github.com/CocoaPods/Specs.git');
+            expect(podSpec.libraries.AFNetworking.spec).toBe('~> 3.2');
+            expect(podSpec.libraries.Eureka['swift-version']).toBe('4.1');
+        });
     });
 
-    it('Test 005: read podspec', function () {
-        const p = new PluginInfo(path.join(pluginsDir, 'org.test.plugins.withcocoapods'));
-        const result = p.getPodSpecs('ios');
-        expect(result.length).toBe(1);
-        const podSpec = result[0];
-        expect(Object.keys(podSpec.declarations).length).toBe(2);
-        expect(Object.keys(podSpec.sources).length).toBe(1);
-        expect(Object.keys(podSpec.libraries).length).toBe(4);
-        expect(podSpec.declarations['use-frameworks']).toBe('true');
-        expect(podSpec.sources['https://github.com/CocoaPods/Specs.git'].source).toBe('https://github.com/CocoaPods/Specs.git');
-        expect(podSpec.libraries.AFNetworking.spec).toBe('~> 3.2');
-        expect(podSpec.libraries.Eureka['swift-version']).toBe('4.1');
+    // describe('Preference', () => {
+    //     // XML passthrough for preferences is not supported because multiple preferences will override each other.
+    //     // https://github.com/apache/cordova-common/issues/182
+    //     // it('Test 007: Preference supports xml passthrough', function () {
+    //     //     const preferences = pluginPassthrough.getPreferences('android');
+    //     //     console.log(preferences);
+    //     //     expect(preferences.passthroughpref.anattrib).toBe('value');
+    //     // });
+    // });
+
+    describe('Asset', () => {
+        it('Test 008: Asset supports xml passthrough', function () {
+            const assets = pluginPassthrough.getAssets('android');
+            expect(assets.length).toBe(1);
+            expect(assets[0].anattrib).toBe('value');
+        });
+    });
+
+    describe('Dependency', () => {
+        it('Test 009: Dependency supports xml passthrough', function () {
+            const dependencies = pluginPassthrough.getDependencies('android');
+            expect(dependencies.length).toBe(1);
+            expect(dependencies[0].anattrib).toBe('value');
+        });
+    });
+
+    describe('Config File', () => {
+        it('Test 010: config-file supports xml passthrough', function () {
+            const configFiles = pluginPassthrough.getConfigFiles('android');
+            expect(configFiles.length).toBe(1);
+            expect(configFiles[0].anattrib).toBe('value');
+        });
+    });
+
+    describe('Edit Config', () => {
+        it('Test 011: edit-config supports xml passthrough', function () {
+            const editConfigs = pluginPassthrough.getEditConfigs('android');
+            expect(editConfigs.length).toBe(1);
+            expect(editConfigs[0].anattrib).toBe('value');
+        });
+    });
+
+    describe('Source File', () => {
+        it('Test 012: source-file supports xml passthrough', function () {
+            const sourceFiles = pluginPassthrough.getSourceFiles('android');
+            expect(sourceFiles.length).toBe(1);
+            expect(sourceFiles[0].anattrib).toBe('value');
+        });
+    });
+
+    describe('Header File', () => {
+        it('Test 013: header-file supports xml passthrough', function () {
+            const headerFiles = pluginPassthrough.getHeaderFiles('android');
+            expect(headerFiles.length).toBe(1);
+            expect(headerFiles[0].anattrib).toBe('value');
+        });
+    });
+
+    describe('Resource File', () => {
+        it('Test 014: resource-file supports xml passthrough', function () {
+            const resourceFiles = pluginPassthrough.getResourceFiles('android');
+            expect(resourceFiles.length).toBe(1);
+            expect(resourceFiles[0].anattrib).toBe('value');
+        });
+    });
+
+    describe('Lib File', () => {
+        it('Test 015: lib-file supports xml passthrough', function () {
+            const libFiles = pluginPassthrough.getLibFiles('android');
+            expect(libFiles.length).toBe(1);
+            expect(libFiles[0].anattrib).toBe('value');
+        });
+    });
+
+    describe('Hook', () => {
+        it('Test 016: hook supports xml passthrough', function () {
+            const hooks = pluginPassthrough.getHookScripts('hi', 'android');
+            expect(hooks.length).toBe(1);
+            expect(hooks[0].attrib.anattrib).toBe('value');
+        });
+    });
+
+    describe('JS Module', () => {
+        it('Test 017: js-modules supports xml passthrough', function () {
+            const modules = pluginPassthrough.getJsModules('android');
+            expect(modules.length).toBe(1);
+            expect(modules[0].anattrib).toBe('value');
+        });
+    });
+
+    describe('Engine', () => {
+        it('Test 018: engine supports xml passthrough', function () {
+            const engines = pluginPassthrough.getEngines('android');
+            expect(engines.length).toBe(1);
+            expect(engines[0].anattrib).toBe('value');
+        });
+    });
+
+    describe('Platform', () => {
+        it('Test 019: platform supports xml passthrough', function () {
+            const platforms = pluginPassthrough.getPlatforms();
+            expect(platforms.length).toBe(1);
+            expect(platforms[0].anattrib).toBe('value');
+        });
     });
 });

--- a/spec/fixtures/plugins/org.test.xmlpassthrough/plugin.xml
+++ b/spec/fixtures/plugins/org.test.xmlpassthrough/plugin.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<plugin xmlns="http://cordova.apache.org/ns/plugins/1.0"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    id="org.test.xmlpassthrough"
+    version="3.0.0">
+
+    <name>For testing xml passthrough</name>
+
+    <!--
+        XML passthrough for preferences is not supported because multiple preferences will override each other.
+        https://github.com/apache/cordova-common/issues/182
+        <preference name="passthroughpref" anattrib="value" />
+    -->
+    <asset src="nope" target="alsono" anattrib="value" />
+    <dependency id="nope" anattrib="value" />
+    <config-file anattrib="value" />    
+    <edit-config anattrib="value" />    
+    <!--Podspec does not support passthrough-->
+    <hook src="hi" type="hi" anattrib="value" />
+    <js-module anattrib="value" />
+    <engines>
+        <engine anattrib="value"/>
+    </engines>
+    <platform name="android" anattrib="value">
+        <source-file anattrib="value" />
+        <header-file anattrib="value" />
+        <resource-file anattrib="value" />
+        <lib-file anattrib="value" />
+    </platform>
+    <framework src="hi" anattrib="value" />    
+</plugin>

--- a/src/PluginInfo/PluginInfo.js
+++ b/src/PluginInfo/PluginInfo.js
@@ -64,6 +64,13 @@ class PluginInfo {
      * @return {Object} { key : default | null}
     */
     getPreferences (platform) {
+        // XML passthrough for preferences is not supported because multiple preferences will override each other.
+        // https://github.com/apache/cordova-common/issues/182
+        // return this._getTags('preference', platform).map(({ attrib }) => {
+        //     return Object.assign({}, attrib, {
+        //         [attrib.name.toUpperCase()]: attrib.default || null
+        //     });
+        // })
         return this._getTags('preference', platform).map(({ attrib }) => ({
             [attrib.name.toUpperCase()]: attrib.default || null
         }))
@@ -84,7 +91,9 @@ class PluginInfo {
                 throw new Error(`Malformed <asset> tag. Both "src" and "target" attributes must be specified in ${this.filepath}`);
             }
 
-            return { itemType: 'asset', src, target };
+            return Object.assign({}, attrib, {
+                itemType: 'asset', src, target
+            });
         });
     }
 
@@ -105,14 +114,14 @@ class PluginInfo {
                 throw new CordovaError(`<dependency> tag is missing id attribute in ${this.filepath}`);
             }
 
-            return {
+            return Object.assign({}, attrib, {
                 id: attrib.id,
                 version: attrib.version || '',
                 url: attrib.url || '',
                 subdir: attrib.subdir || '',
                 commit: attrib.commit,
                 git_ref: attrib.commit
-            };
+            });
         });
     }
 
@@ -122,15 +131,17 @@ class PluginInfo {
      * @param {string} platform
      */
     getConfigFiles (platform) {
-        return this._getTags('config-file', platform).map(tag => ({
-            target: tag.attrib.target,
-            parent: tag.attrib.parent,
-            after: tag.attrib.after,
-            xmls: tag.getchildren(),
-            // To support demuxing via versions
-            versions: tag.attrib.versions,
-            deviceTarget: tag.attrib['device-target']
-        }));
+        return this._getTags('config-file', platform).map(tag => {
+            return Object.assign({}, tag.attrib, {
+                target: tag.attrib.target,
+                parent: tag.attrib.parent,
+                after: tag.attrib.after,
+                xmls: tag.getchildren(),
+                // To support demuxing via versions
+                versions: tag.attrib.versions,
+                deviceTarget: tag.attrib['device-target']
+            });
+        });
     }
 
     /**
@@ -139,12 +150,14 @@ class PluginInfo {
      * @param {string} platform
      */
     getEditConfigs (platform) {
-        return this._getTags('edit-config', platform).map(tag => ({
-            file: tag.attrib.file,
-            target: tag.attrib.target,
-            mode: tag.attrib.mode,
-            xmls: tag.getchildren()
-        }));
+        return this._getTags('edit-config', platform).map(tag => {
+            return Object.assign({}, tag.attrib, {
+                file: tag.attrib.file,
+                target: tag.attrib.target,
+                mode: tag.attrib.mode,
+                xmls: tag.getchildren()
+            });
+        });
     }
 
     /**
@@ -169,14 +182,16 @@ class PluginInfo {
      * @param {string} platform
      */
     getSourceFiles (platform) {
-        return this._getTagsInPlatform('source-file', platform).map(({ attrib }) => ({
-            itemType: 'source-file',
-            src: attrib.src,
-            framework: isStrTrue(attrib.framework),
-            weak: isStrTrue(attrib.weak),
-            compilerFlags: attrib['compiler-flags'],
-            targetDir: attrib['target-dir']
-        }));
+        return this._getTagsInPlatform('source-file', platform).map(({ attrib }) => {
+            return Object.assign({}, attrib, {
+                itemType: 'source-file',
+                src: attrib.src,
+                framework: isStrTrue(attrib.framework),
+                weak: isStrTrue(attrib.weak),
+                compilerFlags: attrib['compiler-flags'],
+                targetDir: attrib['target-dir']
+            });
+        });
     }
 
     /**
@@ -187,12 +202,14 @@ class PluginInfo {
      * @param {string} platform
      */
     getHeaderFiles (platform) {
-        return this._getTagsInPlatform('header-file', platform).map(({ attrib }) => ({
-            itemType: 'header-file',
-            src: attrib.src,
-            targetDir: attrib['target-dir'],
-            type: attrib.type
-        }));
+        return this._getTagsInPlatform('header-file', platform).map(({ attrib }) => {
+            return Object.assign({}, attrib, {
+                itemType: 'header-file',
+                src: attrib.src,
+                targetDir: attrib['target-dir'],
+                type: attrib.type
+            });
+        });
     }
 
     /**
@@ -210,15 +227,17 @@ class PluginInfo {
      * @param {string} platform
      */
     getResourceFiles (platform) {
-        return this._getTagsInPlatform('resource-file', platform).map(({ attrib }) => ({
-            itemType: 'resource-file',
-            src: attrib.src,
-            target: attrib.target,
-            versions: attrib.versions,
-            deviceTarget: attrib['device-target'],
-            arch: attrib.arch,
-            reference: attrib.reference
-        }));
+        return this._getTagsInPlatform('resource-file', platform).map(({ attrib }) => {
+            return Object.assign({}, attrib, {
+                itemType: 'resource-file',
+                src: attrib.src,
+                target: attrib.target,
+                versions: attrib.versions,
+                deviceTarget: attrib['device-target'],
+                arch: attrib.arch,
+                reference: attrib.reference
+            });
+        });
     }
 
     /**
@@ -230,14 +249,16 @@ class PluginInfo {
      * @param {string} platform
      */
     getLibFiles (platform) {
-        return this._getTagsInPlatform('lib-file', platform).map(({ attrib }) => ({
-            itemType: 'lib-file',
-            src: attrib.src,
-            arch: attrib.arch,
-            Include: attrib.Include,
-            versions: attrib.versions,
-            deviceTarget: attrib['device-target'] || attrib.target
-        }));
+        return this._getTagsInPlatform('lib-file', platform).map(({ attrib }) => {
+            return Object.assign({}, attrib, {
+                itemType: 'lib-file',
+                src: attrib.src,
+                arch: attrib.arch,
+                Include: attrib.Include,
+                versions: attrib.versions,
+                deviceTarget: attrib['device-target'] || attrib.target
+            });
+        });
     }
 
     /**
@@ -303,27 +324,33 @@ class PluginInfo {
      * @param {string} platform
      */
     getJsModules (platform) {
-        return this._getTags('js-module', platform).map(tag => ({
-            itemType: 'js-module',
-            name: tag.attrib.name,
-            src: tag.attrib.src,
-            clobbers: tag.findall('clobbers').map(tag => ({ target: tag.attrib.target })),
-            merges: tag.findall('merges').map(tag => ({ target: tag.attrib.target })),
-            runs: tag.findall('runs').length > 0
-        }));
+        return this._getTags('js-module', platform).map(tag => {
+            return Object.assign({}, tag.attrib, {
+                itemType: 'js-module',
+                name: tag.attrib.name,
+                src: tag.attrib.src,
+                clobbers: tag.findall('clobbers').map(tag => ({ target: tag.attrib.target })),
+                merges: tag.findall('merges').map(tag => ({ target: tag.attrib.target })),
+                runs: tag.findall('runs').length > 0
+            });
+        });
     }
 
     getEngines () {
-        return this._et.findall('engines/engine').map(({ attrib }) => ({
-            name: attrib.name,
-            version: attrib.version,
-            platform: attrib.platform,
-            scriptSrc: attrib.scriptSrc
-        }));
+        return this._et.findall('engines/engine').map(({ attrib }) => {
+            return Object.assign({}, attrib, {
+                name: attrib.name,
+                version: attrib.version,
+                platform: attrib.platform,
+                scriptSrc: attrib.scriptSrc
+            });
+        });
     }
 
     getPlatforms () {
-        return this._et.findall('platform').map(n => ({ name: n.attrib.name }));
+        return this._et.findall('platform').map(n => {
+            return Object.assign({}, n.attrib, { name: n.attrib.name });
+        });
     }
 
     getPlatformsArray () {
@@ -346,21 +373,23 @@ class PluginInfo {
         // Replaces plugin variables in s if they exist
         const expandVars = s => varExpansions.reduce((acc, fn) => fn(acc), s);
 
-        return this._getTags('framework', platform).map(({ attrib }) => ({
-            itemType: 'framework',
-            type: attrib.type,
-            parent: attrib.parent,
-            custom: isStrTrue(attrib.custom),
-            embed: isStrTrue(attrib.embed),
-            src: expandVars(attrib.src),
-            spec: attrib.spec,
-            weak: isStrTrue(attrib.weak),
-            versions: attrib.versions,
-            targetDir: attrib['target-dir'],
-            deviceTarget: attrib['device-target'] || attrib.target,
-            arch: attrib.arch,
-            implementation: attrib.implementation
-        }));
+        return this._getTags('framework', platform).map(({ attrib }) => {
+            return Object.assign({}, attrib, {
+                itemType: 'framework',
+                type: attrib.type,
+                parent: attrib.parent,
+                custom: isStrTrue(attrib.custom),
+                embed: isStrTrue(attrib.embed),
+                src: expandVars(attrib.src),
+                spec: attrib.spec,
+                weak: isStrTrue(attrib.weak),
+                versions: attrib.versions,
+                targetDir: attrib['target-dir'],
+                deviceTarget: attrib['device-target'] || attrib.target,
+                arch: attrib.arch,
+                implementation: attrib.implementation
+            });
+        });
     }
 
     getFilesAndFrameworks (platform, options) {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
All


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Closes https://github.com/apache/cordova-common/pull/179 (superceeds #179)

Currently, adding attributes to the XML tags requires a lot of repos to update.

cordova-common to read the new XML tag.
cordova-lib and cordova cli need to update their dependencies. 
People need to update cordova-cli to have the cordova-common update.

Each platform that wants to use the new attribute needs to be updated.
cordova-docs also needs to be updated.

Depending on the number of platforms that needs the update you're looking at 5 or more repos requiring an update, even when it's simply add a brand new attribute to an XML tag.


This PR updates the XML parsing code to passthrough all attributes.
Existing attributes are parsed in the same way there parsed before. New attributes will be passed through without any addition parsing.

The intention is to stop requiring cordova-common updates in order to add attributes to XML tags.


The benefit of this PR is that it removes the need to update 3 repos when modifying supported XML tags. Those 3 repos being cordova-common, cordova-lib, and cordova-cli.

### Description
<!-- Describe your changes in detail -->
Copies all attributes from XML tags to the return object in the respective XML tag get functions.

Existing attributes are still parsed in the exact same way as before.
E.X framework attribute "embed" is still passed through isStrTrue.

I don't believe any cordova-docs updates are required.

### Testing
<!-- Please describe in detail how you tested your changes. -->

I've added unit tests for XML passthrough.

I've ran npm test on cordova-common, cordova-lib, cordova-cli. lib and cli were updated with the cordova-common change.
I've ran these changes on my company's app.

An update in my company's attribute is requiring me to add an new attribute to the framework tag. I've tested adding a new attribute to cordova-ios with my company's app using these changes.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
