### PR TITLE
chore: 4.1.0-dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cordova-common",
-  "version": "4.0.3-dev",
+  "version": "4.1.0-dev",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cordova-common",
-      "version": "4.0.3-dev",
+      "version": "4.1.0-dev",
       "license": "Apache-2.0",
       "dependencies": {
         "@netflix/nerror": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "cordova-common",
   "description": "Apache Cordova tools and platforms shared routines",
   "license": "Apache-2.0",
-  "version": "4.0.3-dev",
+  "version": "4.1.0-dev",
   "repository": "github:apache/cordova-common",
   "bugs": "https://github.com/apache/cordova-common/issues",
   "main": "cordova-common.js",


### PR DESCRIPTION
Simply a bump of the version to 4.1.0-dev to signal next release is a minor.