### PR TITLE
android: added monochrome attribute

### DIFF
--- a/src/ConfigParser/ConfigParser.js
+++ b/src/ConfigParser/ConfigParser.js
@@ -567,6 +567,7 @@ class ImageResource extends BaseResource {
         this.height = Number(attrs.height) || undefined;
         this.background = attrs.background || undefined;
         this.foreground = attrs.foreground || undefined;
+        this.monochrome = attrs.monochrome || undefined;
     }
 }
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
- android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Android 13 added support for Themed Icons. Since themed icons aren't yet supported on Cordova Android, adding support for Themed icons inside `cordova-android` required modification to this project as the former project uses `getStaticResources` function defined inside `cordova-common`

https://github.com/apache/cordova-android/issues/1450

### Description
<!-- Describe your changes in detail -->
Added support for parsing the monochrome icon for Android when preparing / updating the icons.


### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
