### PR TITLE
test: Removed obsolete test

### DIFF
--- a/spec/PluginInfo/PluginInfo.spec.js
+++ b/spec/PluginInfo/PluginInfo.spec.js
@@ -84,16 +84,6 @@ describe('PluginInfo', function () {
         });
     });
 
-    // describe('Preference', () => {
-    //     // XML passthrough for preferences is not supported because multiple preferences will override each other.
-    //     // https://github.com/apache/cordova-common/issues/182
-    //     // it('Test 007: Preference supports xml passthrough', function () {
-    //     //     const preferences = pluginPassthrough.getPreferences('android');
-    //     //     console.log(preferences);
-    //     //     expect(preferences.passthroughpref.anattrib).toBe('value');
-    //     // });
-    // });
-
     describe('Asset', () => {
         it('Test 008: Asset supports xml passthrough', function () {
             const assets = pluginPassthrough.getAssets('android');


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

None

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

There was a test commented out due to lacking support of passing through XML attributes on preference tags, as documented [here](https://github.com/apache/cordova-common/issues/182), however it was decided that this is not going to be a supported feature.

This pr just removes the commented out test.

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->

Ran npm test

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
