### PR TITLE
chore: Minor test fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,8 @@
         "jasmine": "^4.5.0",
         "jasmine-spec-reporter": "^7.0.0",
         "nyc": "^15.1.0",
-        "rewire": "^6.0.0"
+        "rewire": "^6.0.0",
+        "tmp": "^0.2.3"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -4643,6 +4644,16 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "node_modules/tmp": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
+      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "jasmine": "^4.5.0",
     "jasmine-spec-reporter": "^7.0.0",
     "nyc": "^15.1.0",
-    "rewire": "^6.0.0"
+    "rewire": "^6.0.0",
+    "tmp": "^0.2.3"
   },
   "nyc": {
     "all": true,

--- a/spec/ConfigChanges/ConfigChanges.spec.js
+++ b/spec/ConfigChanges/ConfigChanges.spec.js
@@ -18,9 +18,11 @@
 */
 
 const fs = require('node:fs');
-const os = require('node:os');
 const path = require('node:path');
 const et = require('elementtree');
+const tmp = require('tmp');
+
+tmp.setGracefulCleanup();
 
 const configChanges = require('../../src/ConfigChanges/ConfigChanges');
 const mungeutil = require('../../src/ConfigChanges/munge-util');
@@ -54,7 +56,8 @@ const varplugin = path.join(fixturePath, 'plugins/com.adobe.vars');
 const plistplugin = path.join(fixturePath, 'plugins/org.apache.plist');
 const bplistplugin = path.join(fixturePath, 'plugins/org.apache.bplist');
 
-const temp = path.join(os.tmpdir(), 'plugman');
+const tempdir = tmp.dirSync({ unsafeCleanup: true });
+const temp = path.join(tempdir.name, 'plugman');
 const plugins_dir = path.join(temp, 'cordova', 'plugins');
 
 const cfg = new ConfigParser(xml);

--- a/spec/FileUpdater.spec.js
+++ b/spec/FileUpdater.spec.js
@@ -39,10 +39,42 @@ FileUpdater.__set__('updatePathWithStats', function () {
 
 // Create mock fs.Stats to simulate file or directory attributes.
 function mockFileStats (modified) {
-    return new Stats(0, 32768, 0, 0, 0, 0, 0, 0, 0, 0, null, modified, modified, null);
+    return {
+        __proto__: Stats.prototype,
+        dev: 0,
+        mode: 32768,
+        nlink: 0,
+        uid: 0,
+        gid: 0,
+        rdev: 0,
+        blksize: 0,
+        ino: 0,
+        size: 0,
+        blocks: 0,
+        atime: null,
+        mtime: modified,
+        ctime: modified,
+        birthtime: null
+    };
 }
 function mockDirStats () {
-    return new Stats(0, 16384, 0, 0, 0, 0, 0, 0, 0, 0, null, null, null, null);
+    return {
+        __proto__: Stats.prototype,
+        dev: 0,
+        mode: 16384,
+        nlink: 0,
+        uid: 0,
+        gid: 0,
+        rdev: 0,
+        blksize: 0,
+        ino: 0,
+        size: 0,
+        blocks: 0,
+        atime: null,
+        mtime: null,
+        ctime: null,
+        birthtime: null
+    };
 }
 
 class SystemError extends Error {


### PR DESCRIPTION
### Platforms affected
None


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Resolves some deprecations warnings printed to the console in Node 22.


### Description
<!-- Describe your changes in detail -->
* The `fs.Stats` constructor is deprecated in Node 22 and prints a warning to the console, so we want to find a way to avoid hitting that
* We got some warnings elsewhere that temporary files weren't cleaned up properly after test runs. Try using the `tmp` npm module to handle this better


### Testing
<!-- Please describe in detail how you tested your changes. -->
Ran unit tests locally on Node 22.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
