### PR TITLE
feat(spm): Add method to determine if a plugin is a Swift package

### DIFF
--- a/spec/PluginInfo/PluginInfo.spec.js
+++ b/spec/PluginInfo/PluginInfo.spec.js
@@ -179,4 +179,16 @@ describe('PluginInfo', function () {
             expect(platforms[0].anattrib).toBe('value');
         });
     });
+
+    describe('isSwiftPackage', () => {
+        it('Test 020: returns false for non-annotated plugins', function () {
+            const p = new PluginInfo(path.join(pluginsDir, 'org.test.plugins.withcocoapods'));
+            expect(p.isSwiftPackage()).toBe(false);
+        });
+
+        it('Test 021: returns true for annotated plugins', function () {
+            const p = new PluginInfo(path.join(pluginsDir, 'org.test.plugins.swiftpackage'));
+            expect(p.isSwiftPackage()).toBe(true);
+        });
+    });
 });

--- a/spec/fixtures/plugins/org.test.plugins.swiftpackage/plugin.xml
+++ b/spec/fixtures/plugins/org.test.plugins.swiftpackage/plugin.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<plugin xmlns="http://cordova.apache.org/ns/plugins/1.0"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    id="org.test.plugins.withcocoapods"
+    version="0.6.0">
+
+    <!-- new requirement: NO SPACES -->
+    <name>swiftpackage</name>
+    <!-- These are going to be required by plugman-registry -->
+    <description>my description</description>
+    <author>Darryl Pogue</author>
+    <keywords>dummy,plugin,swift</keywords>
+    <license>BSD</license>
+    <!-- end plugman-registry requirements -->
+
+    <!-- ios -->
+    <platform name="ios" package="swift">
+    </platform>
+</plugin>

--- a/src/PluginInfo/PluginInfo.js
+++ b/src/PluginInfo/PluginInfo.js
@@ -411,6 +411,19 @@ class PluginInfo {
     }
 
     /**
+     * Helper method to determine if this plugin is distributed as a Swift
+     * package.
+     *
+     * @example
+     * <platform name="ios" package="swift">
+     * </platform>
+     */
+    isSwiftPackage () {
+        const platformTag = this._et.find('./platform[@name="ios"]');
+        return !!platformTag.attrib.package;
+    }
+
+    /**
      * Helper method used by most of the getSomething methods of PluginInfo.
      *
      * Get all elements of a given name. Both in root and in platform sections


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
We want a declarative way for a plugin to opt-in to using Package.swift for managing its code and resources as opposed to file copying with `source-file`/`header-file`/`resource-file`/etc.


### Description
<!-- Describe your changes in detail -->
Adds a helper method to detect if there is a `<platform name="ios" package="swift">` tag.

Caveats:
* This currently only looks at the first iOS platform declaration
* This doesn't currently check the value of the `package` attribute. If it exists, we assume it is a Swift package. Ideally I'd love for this to be a boolean attribute like in HTML, but XML doesn't support those 😒 


### Testing
<!-- Please describe in detail how you tested your changes. -->
Added unit test case.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change