### PR TITLE
ci: add permissions block & commit hash pinning of third-party actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,10 @@ on:
     branches:
       - '*'
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   test:
     name: NodeJS ${{ matrix.node-version }} on ${{ matrix.os }}
@@ -63,7 +67,8 @@ jobs:
 
       - uses: github/codeql-action/analyze@v3
 
-      - uses: codecov/codecov-action@v4
+      # v4.6.0
+      - uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238
         if: success()
         with:
           name: ${{ runner.os }} node.js ${{ matrix.node-version }}

--- a/.github/workflows/release-audit.yml
+++ b/.github/workflows/release-audit.yml
@@ -25,6 +25,9 @@ on:
     branches:
       - '*'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Audit Licenses
@@ -33,8 +36,8 @@ jobs:
       # Checkout project
       - uses: actions/checkout@v4
 
-      # Check license headers
-      - uses: erisu/apache-rat-action@v1
+      # Check license headers (v1.2.0)
+      - uses: erisu/apache-rat-action@3127a8c18f3bb10e91c60e835144085b31c5c463
 
       # Setup environment with node
       - uses: actions/setup-node@v4
@@ -45,7 +48,7 @@ jobs:
       - name: npm install packages
         run: npm i
 
-      # Check node package licenses
+      # Check node package licenses (v1.0.0)
       - uses: erisu/license-checker-action@e929758f9416f30234ac454fc9054ca4b803871d
         with:
           license-config: 'licence_checker.yml'


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

n/a

### Motivation, Context & Description
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- Add permissions block to GH Actions
- Pin third-party actions to commit hash (per ASF policy)

### Testing
<!-- Please describe in detail how you tested your changes. -->

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
