### PR TITLE
feat!: change resource-file behavior to support directory contents

### DIFF
--- a/spec/FileUpdater.spec.js
+++ b/spec/FileUpdater.spec.js
@@ -180,9 +180,9 @@ describe('FileUpdater class', function () {
             const updated = FileUpdater.updatePathWithStats(
                 testSourceDir, mockDirStats(), testTargetDir, null);
             expect(updated).toBe(true);
-            expect(mockFs.mkdirPaths.length).toBe(1);
+            expect(mockFs.cpPaths.length).toBe(1);
             expect(mockFs.rmPaths.length).toBe(0);
-            expect(mockFs.mkdirPaths[0]).toBe(testTargetDir);
+            expect(mockFs.cpPaths[0]).toEqual([testSourceDir, testTargetDir]);
         });
 
         it('Test 003 : should remove a directory that exists at target and not at source', function () {
@@ -275,11 +275,10 @@ describe('FileUpdater class', function () {
             const updated = FileUpdater.updatePathWithStats(
                 testSourceDir, mockDirStats(), testTargetDir, mockFileStats(now));
             expect(updated).toBe(true);
-            expect(mockFs.cpPaths.length).toBe(0);
+            expect(mockFs.cpPaths.length).toBe(1);
             expect(mockFs.rmPaths.length).toBe(1);
-            expect(mockFs.mkdirPaths.length).toBe(1);
             expect(mockFs.rmPaths[0]).toBe(testTargetDir);
-            expect(mockFs.mkdirPaths[0]).toBe(testTargetDir);
+            expect(mockFs.cpPaths[0]).toEqual([testSourceDir, testTargetDir]);
         });
 
         it('Test 013 : should remove and copy when source is a file and target is a directory', function () {

--- a/src/FileUpdater.js
+++ b/src/FileUpdater.js
@@ -81,9 +81,9 @@ function updatePathWithStats (sourcePath, sourceStats, targetPath, targetStats, 
     }
 
     if (sourceStats.isDirectory() && !targetStats) {
-        // The target directory does not exist, so we create it.
-        log(`mkdir ${targetPath}`);
-        fs.mkdirSync(targetFullPath, { recursive: true });
+        // The target directory does not exist, so recursive copy to create it and its contents.
+        log(`cpSync ${targetPath}`);
+        fs.cpSync(path.join(rootDir, sourcePath), targetFullPath, { recursive: true });
         return true;
     }
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

All

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Resolves #213

### Description
<!-- Describe your changes in detail -->

This breaking change wil change the behavior of `<resource-file>`.

`<resource-file>`, as its named,  only supported copying individual files. As far as I am aware, this is how it has always been documented and described.

This PR basically change the understanding of how `resource-file` works. It will now include copying of `directories` and all of its inner content recursively.

This PR will only deal with the recursive copy of directories. Platforms might need to improve its own logic to determine how it should handle what is copied over. 

For example Cordova-iOS would have added each resource file to the pbxproj as resource. With this change, it wont add all files and folders to the pbxproj as resources and it might not add what you expect, depending on how the `resource-file` is used.

### Testing
<!-- Please describe in detail how you tested your changes. -->

- `npm t`
- Simple build test.

Added to `config.xml`
```
<resource-file src="res/Test" target="../Test" />
```

Created directory `res/Test` with contents:

```
res/Test
├── Test1.md
└── Test2
    └── Test2.md
```

Confirmed folder `Test` and files were added to `platforms/ios/HelloCordova/Test`.
Confirmed in pbxproj the following resource was added.

```
/* Test */ = {isa = PBXFileReference; name = "Test"; path = "../Test"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
```

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
